### PR TITLE
add affiliation in person metadata

### DIFF
--- a/v3.0/core/person.schema.json
+++ b/v3.0/core/person.schema.json
@@ -44,6 +44,23 @@
         ]
       }
     },
+    "affiliations": {
+      "type": "array",
+      "description": "List of institutions",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The full name of the affiliation (address); usually the name of an institute or company."
+          },
+          "PID": {
+            "type": "string",
+            "description": "RINGGOLD number"
+          }
+        }
+      }
+    },
     "isMainContactOf": {
       "type": "array",
       "description": "Resources for which person is the main contact.",


### PR DESCRIPTION
it would be worth looking into the PID there, Orcid is using ringold number (for me at least) but the ROR are in development. Should this be more flexible, or do you want to keep only the text version ?
Or would you like to add indexes here, and take affiliation as another json file?