### PR TITLE
Max. length for character string

### DIFF
--- a/v3.0/core/dataset.schema.json
+++ b/v3.0/core/dataset.schema.json
@@ -21,11 +21,13 @@
   "properties": {
     "alias": {
       "type": "string",
-      "description": "User-defined identifier of this dataset."
+      "description": "User-defined identifier of this dataset.",
+      "maxLength": 30
     },
     "headline": {
       "type": "string",
-      "description": "Headline that describes this dataset (max. 110 characters)."
+      "description": "Headline that describes this dataset (max. 110 characters).",
+      "maxLength": 110
     },
     "abstract": {
       "type": "string",


### PR DESCRIPTION
Character limits for alias and headline should be define with (minLength and) maxLength (not only in description). I left out minLength because it is redunant since both properties are required.
Alias should have a maximum, too, we don't want too long aliases. Then the point of having it is lost, right?