### PR TITLE
dataset.schema.json update suggestions

### DIFF
--- a/v3.0/core/dataset.schema.json
+++ b/v3.0/core/dataset.schema.json
@@ -21,11 +21,13 @@
   "properties": {
     "alias": {
       "type": "string",
-      "description": "User-defined identifier of this dataset."
+      "description": "User-defined identifier of this dataset.",
+      "maxLength": 30
     },
     "headline": {
       "type": "string",
-      "description": "Headline that describes this dataset (max. 110 characters)."
+      "description": "Headline that describes this dataset (max. 110 characters).",
+      "maxLength": 110
     },
     "abstract": {
       "type": "string",

--- a/v3.0/core/dataset.schema.json
+++ b/v3.0/core/dataset.schema.json
@@ -43,7 +43,7 @@
     },
     "changeLog": {
       "type": "string",
-      "description": "Record of all notable changes made to this dataset compared to it's previous version."
+      "description": "Record of all notable changes made to this dataset compared to its previous version."
     },
     "license": {
       "description": "Link to license document that applies to this dataset.",
@@ -58,7 +58,7 @@
     },
     "conditionsOfAccess": {
       "type": "string",
-      "description": "General condition that defines the availability of this dataset.",
+      "description": "General condition that defines the availability of the data related to this dataset.",
       "enum": [
         "embargoed",
         "open",
@@ -73,11 +73,11 @@
     },
     "contributors": {
       "type": "array",
-      "description": "Link to list of persons that were involved in the creation/publication of this dataset.",
+      "description": "Link to person(s) that were involved in the creation/publication of this dataset.",
       "minItems": 1,
-      "maxItems": 1,
+      "uniqueItems": true,
       "items": {
-        "$ref": "https://schema.hbp.eu/minds3.0/options/contributors.schema.json"
+        "$ref": "https://schema.hbp.eu/minds3.0/options/person.schema.json"
       }
     },
     "ethicsApproval": {
@@ -133,11 +133,11 @@
         "$ref": "https://schema.hbp.eu/minds3.0/core/publicationOrSource.schema.json"
       }
     },
-    "usedMethodsAndOrParadigms": {
+    "usedTechnique": {
       "type": "array",
-      "description": "Lists the methods and/or paradigms used to produce this content.",
+      "description": "Lists the technique(s) used to produce this content.",
       "items": {
-        "$ref": "https://schema.hbp.eu/minds3.0/core/methodsOrParadigms.schema.json"
+        "$ref": "https://schema.hbp.eu/minds3.0/core/technique.schema.json"
       }
     }
   }


### PR DESCRIPTION
Additional questions: 
1. dataDescriptor: Do you intend to have the text of the data descriptor copied as a string to this field? Would this mean that figures in the data descriptor wouldn't be allowed anymore or would this be in addition to a downloadable file of it?
2. changeLog: We may want to add a field to provide a URL to the documentation for the changes (as optional additional property). For dataset, this will most oftenly not be used, but as we discussed for e.g. delineations of an atlas detailed documentation may be available.   
3. Contributors: I read up on minItem/maxItem and if I understand them correctly, you limited the contributor list to one contributor (one item). So, I removed it here. I also added uniqueItems, because I wasn't sure if this is by default true or false. Additionally, I changed the $ref from ...contributors.schema.json to ...person.schema.json. Was this on purpose and there will be a contributor schema? Was this the reason there was ´"maxItems": 1´?
4. isBasedOn: I'm lacking $ref to dataset and model here. A dataset could be based on another dataset or a model. Or is this intended to mean something else?
