### PR TITLE
Update dataset.schema.json

### DIFF
--- a/v1.0/core/dataset.schema.json
+++ b/v1.0/core/dataset.schema.json
@@ -4,6 +4,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "Structured information describing a collection of human and/or animal data.",
   "type": "object",
+  "definitions": {
+    "$ref": "https://raw.githubusercontent.com/HumanBrainProject/openMINDS/master/v1.0/definitions.json"
+  },
   "additionalProperties": false,
   "required": [
     "@type",
@@ -39,45 +42,45 @@
       "type": "array",
       "description": "Link to all activities that were performed for generating this dataset.",
       "items": {
-        "$ref": "https://schema.hbp.eu/minds/core/project.schema.json"
+        "$ref": "#core/activity"
       }
     },
     "owners": {
       "type": "array",
       "description": "Link to all persons that are responsible for this dataset.",
       "items": {
-        "$ref": "https://schema.hbp.eu/minds/core/person.schema.json"
+        "$ref": "#core/person"
       }
     },
     "contributors": {
       "type": "array",
       "description": "Link to all persons that were involved in the creation/publication of this dataset.",
       "items": {
-        "$ref": "https://schema.hbp.eu/minds/core/person.schema.json"
+        "$ref": "#core/person"
       }
     },
     "license": {
       "type": "object",
       "description": "Link to a license that defines the conditions under which this dataset can be (re)used.",
-      "$ref": "https://schema.hbp.eu/minds/options/license.schema.json"
+      "$ref": "#core/licensetype"
     },
     "embargoStatus": {
       "type": "object",
       "description": "Link to the general condition that defines the availability of this dataset.",
-      "$ref": "https://schema.hbp.eu/minds/core/embargostatus.schema.json"
+      "$ref": "#core/embargostatus"
     },
     "specimenGroups": {
       "type": "array",
       "description": "Link to all specimen groups listing the subjects that were studied in this dataset.",
       "items": {
-        "$ref": "https://schema.hbp.eu/minds/core/specimengroup.schema.json"
+        "$ref": "#core/specimengroup"
       }
     },
     "publications": {
       "type": "array",
       "description": "Link to all research publications that were conducted on / are related to this dataset.",
       "items": {
-        "$ref": "https://schema.hbp.eu/minds/core/publication.schema.json"
+        "$ref": "#core/publication"
       }
     },
     "file": {
@@ -91,21 +94,21 @@
       "type": "array",
       "description": "Link to all file formats used in this dataset.",
       "items": {
-        "$ref": "https://schema.hbp.eu/minds/core/formats.schema.json"
+        "$ref": "#core/format"
       }
     },
     "project": {
       "type": "array",
       "description": "Link to all larger research projects in which context this dataset was created.",
       "items": {
-        "$ref": "https://schema.hbp.eu/minds/core/placomponent.schema.json"
+        "$ref": "#core/placomponent"
       }
     },
     "modality": {
       "type": "array",
       "description": "Link to all experiment modalities that were conducted in this dataset.",
       "items": {
-        "$ref": "https://schema.hbp.eu/minds/core/modality.schema.json"
+        "$ref": "#core/modality"
       }
     },
     "containerURL": {
@@ -147,14 +150,14 @@
       "type": "array",
       "description": "Link to all brain reference spaces that were used in this dataset.",
       "items": {
-        "$ref": "https://schema.hbp.eu/minds/core/referencespace.schema.json"
+        "$ref": "#core/referencespace"
       }
     },
     "versionOf": {
       "type": "array",
       "description": "Link to all previous versions of this dataset.",
       "items": {
-        "$ref": "https://schema.hbp.eu/minds/core/dataset.schema.json"
+        "$ref": "#core/dataset"
       }
     }
   }


### PR DESCRIPTION
in relation to #19 

Additional remarks: 
- Line 45: ref to `"https://schema.hbp.eu/minds/core/project.schema.json"` --> 1. problem: project.schema.json doesn't exist (it should have been placomponent according to definitions file); 2. problem: property here is `"activity"`, not project/placomponent.
I added `"#core/activity"` as I think this should be the correct reference. 
- Line 65: ref was `https://schema.hbp.eu/minds/options/license.schema.json` but schema is called `.../licensetype.schema.json` in definitions file
- Line 90: What to do for files ref? No schema/not part of minds and therefore not included in definitions. Leave it be?
- Line 97: ref was `https://schema.hbp.eu/minds/core/formats.schema.json` but schema is called `.../format.schema.json` (without the s) in definitions file
- Line 133: What to do for doi ref? No schema/not part of minds and therefore not included in definitions. Leave it be?
- Line 139 & 146: What to do for parcellationatlas & parcellationregion ref? No schemata and therefore not included in definitions. Leave it be? But they are actually part of minds (according to ref). Add schemate for them to v1?