### PR TITLE
prototype of collection-generator with methods and dynamic docstrings

### DIFF
--- a/collection-generator.py
+++ b/collection-generator.py
@@ -67,7 +67,6 @@ class CollectionGenerator:
                     
             # open openMINDS json-schema to find out it's properties
             with open(rp2s, 'r') as fp:
-                print(rp2s)
                 jschema = json.load(fp)
             fp.close()
             
@@ -80,6 +79,8 @@ class CollectionGenerator:
             jschema['required'].append('at_id')
             
             # create method from schema using warlock
-            setattr(self.schemas, sn, warlock.model_factory(jschema)) 
-
-        
+            setattr(self.schemas, sn, warlock.model_factory(jschema))
+            
+            # create docstring for each schema-method
+            sm = getattr(self.schemas, sn)
+            sm.__doc__ = """This is the documentation of %s""" % sn

--- a/collection-generator.py
+++ b/collection-generator.py
@@ -11,37 +11,24 @@ import warlock
 import collections
 
 class CollectionGenerator:
-#    """
-#    Class for generating an openMINDS conform metadata collection.
-#    
-#    The CollectionGenerator class dynamically reads the openMINDS schemas of a 
-#    given version for generating, validating, and storing corresponding json-LD 
-#    metadata files in an openMINDS conform metadata collection. 
-#        
-#    Attributes
-#    ----------
-#    version2use : str
-#        Used version of openMINDS schemas.
-#    store2 : str
-#        Absolute file path to where the openMINDS metadata collection is going 
-#        to be stored. 
-#        
-#    Methods
-#    -------
-#    """
-    _class_docstring_temp = " ". join(
-            ["Class", "for", "generating", "an", "openMINDS", "conform", 
-             "metadata", "collection.", "\n\nThe", "CollectionGenerator",
-             "class", "dynamically", "reads", "the", "openMINDS", "schemas", 
-             "of", "a", "\ngiven", "version", "for", "generating,", 
-             "validating,", "and", "storing", "corresponding", "json-LD",
-             "\nmetadata", "files", "in", "an", "openMINDS", "conform", 
-             "metadata", "collection", "\n\nAttributes", "\n----------",
-             "\nversion2use : str", "\n    Used", "version", "of", "openMINDS",
-             "schemas.", "\nstore2 : str", "\n    Absolute", "file", "path", 
-             "to", "where", "the", "openMINDS", "metadata", "collection", 
-             "is", "going", "\n    to", "be", "stored.", "\n\nMethods",
-             "\n-------"])
+    """
+    Class for generating an openMINDS conform metadata collection.
+    
+    The CollectionGenerator class dynamically reads the openMINDS schemas of a 
+    given version for generating, validating, and storing corresponding json-LD 
+    metadata files in an openMINDS conform metadata collection. 
+        
+    Attributes
+    ----------
+    version2use : str
+        Used version of openMINDS schemas.
+    store2 : str
+        Absolute file path to where the openMINDS metadata collection is going 
+        to be stored. 
+        
+    Methods
+    -------
+    """
     _method_docstring_temp = " ".join(
             ["Generates", "a", "dictionary", "that", "is", "conform", "with", 
              "\nthe", "openMINDS", "({version2use})", "schema", "{sn}.", 
@@ -127,6 +114,6 @@ class CollectionGenerator:
             # collect method description
             method_desc += "".join(["\n    ", sn, "(",
                     ", ".join(sorted(list(jschema['properties'].keys()))), ")"])
-
-        self.__doc__ = self._class_docstring_temp + method_desc
-        inspect.cleandoc(self)
+        
+        # add schema methods summary to class docstring
+        self.__doc__ += method_desc

--- a/collection-generator.py
+++ b/collection-generator.py
@@ -6,7 +6,6 @@ Created on Tue May 19 11:22:51 2020
 @author: zehl
 """
 import json
-import inspect
 import warlock
 import collections
 

--- a/collection-generator.py
+++ b/collection-generator.py
@@ -11,24 +11,43 @@ import warlock
 import collections
 
 class CollectionGenerator:
-    """
-    Class for generating an openMINDS conform metadata collection.
-    
-    The CollectionGenerator class dynamically reads the openMINDS schemas of a 
-    given version for generating, validating, and storing corresponding json-LD 
-    metadata files in an openMINDS conform metadata collection. 
-        
-    Attributes
-    ----------
-    version2use : str
-        Used version of openMINDS schemas.
-    store2 : str
-        Absolute file path to where the openMINDS metadata collection is going 
-        to be stored. 
-        
-    Methods
-    -------
-    """
+#    """
+#    Class for generating an openMINDS conform metadata collection.
+#    
+#    The CollectionGenerator class dynamically reads the openMINDS schemas of a 
+#    given version for generating, validating, and storing corresponding json-LD 
+#    metadata files in an openMINDS conform metadata collection. 
+#        
+#    Attributes
+#    ----------
+#    version2use : str
+#        Used version of openMINDS schemas.
+#    store2 : str
+#        Absolute file path to where the openMINDS metadata collection is going 
+#        to be stored. 
+#        
+#    Methods
+#    -------
+#    """
+    _class_docstring_temp = " ". join(
+            ["Class", "for", "generating", "an", "openMINDS", "conform", 
+             "metadata", "collection.", "\n\nThe", "CollectionGenerator",
+             "class", "dynamically", "reads", "the", "openMINDS", "schemas", 
+             "of", "a", "\ngiven", "version", "for", "generating,", 
+             "validating,", "and", "storing", "corresponding", "json-LD",
+             "\nmetadata", "files", "in", "an", "openMINDS", "conform", 
+             "metadata", "collection", "\n\nAttributes", "\n----------",
+             "\nversion2use : str", "\n    Used", "version", "of", "openMINDS",
+             "schemas.", "\nstore2 : str", "\n    Absolute", "file", "path", 
+             "to", "where", "the", "openMINDS", "metadata", "collection", 
+             "is", "going", "\n    to", "be", "stored.", "\n\nMethods",
+             "\n-------"])
+    _method_docstring_temp = " ".join(
+            ["Generates", "a", "dictionary", "that", "is", "conform", "with", 
+             "\nthe", "openMINDS", "({version2use})", "schema", "{sn}.", 
+             "\n\nParameters\n----------", "\n    DYNAMINCALLY-BUILT", 
+             "\n\nReturns\n-------", "\n    Dictionary", "conform", "with", 
+             "the", "openMINDS", "\n    ({version2use})", "schema", "{sn}."])
     
     def __init__(self, version2use, store2):
         """
@@ -59,6 +78,7 @@ class CollectionGenerator:
         self.schemas = collections.namedtuple('schemas', schema_names)
         
         # transpose schema attributes to schema subclasses
+        method_desc = ""
         for sn in schema_names:
             # define relative path to openMINDS schema
             rp2s = '/'.join([rpv, 
@@ -81,53 +101,32 @@ class CollectionGenerator:
             # create method from schema using warlock
             setattr(self.schemas, sn, warlock.model_factory(jschema))
             
-            # create dynamic docstrings for each schema method
-            method_desc = inspect.cleandoc(
-                    """
-                    Generates a dictionary that is conform with the openMINDS 
-                    ({version2use}) schema {sn}.
-                    """)
-            params_str = inspect.cleandoc(
-                    """
-                    Parameters
-                    ----------
-                    """)
-            return_str = inspect.cleandoc(
-                    """
-                    Returns
-                    -------
-                    """)
-            method_return_desc = inspect.cleandoc(
-                    """
-                        Dictionary conform with the openMINDS ({version2use}) 
-                        schema {sn}.
-                    """)
+            # create dynamic docstring for each schema method
+            method_params = ""
             for p, d in jschema['properties'].items():
-                method_params = inspect.cleandoc(
-                        """
-                        {p} : {d['type']}
-                        """)
+                method_params += " ".join(
+                        ["\n   ", p, ":", d['type']])
                 for k, v in d.items():
                     if k == 'type':
-                        pass
+                        continue
                     elif k == 'items':
-                        method_params = inspect.cleandoc(
-                                method_params + 
-                                """ 
-                                    expects - {str(v)}
-                                """)
+                        method_params += " ".join(
+                                ["\n\texpects -", str(v)])
                     else:
-                        method_params = inspect.cleandoc(
-                                method_params + 
-                                """ 
-                                    {k} - {str(v)}
-                                """)
-            docu = inspect.cleandoc(
-                    method_desc +
-                    params_str +
-                    method_params +
-                    return_str +
-                    method_return_desc
-                    )
+                        method_params += " ".join(
+                                ["\n       ", k, "-", str(v)])
+            temp_docstr = self._method_docstring_temp.format(
+                    version2use=version2use, sn=sn)
+            
+            # update method docstring
             sm = getattr(self.schemas, sn)
-            sm.__doc__ = docu
+            sm.__name__ = sn
+            sm.__doc__ = temp_docstr.replace(
+                    "\n    DYNAMINCALLY-BUILT", method_params)
+                
+            # collect method description
+            method_desc += "".join(["\n    ", sn, "(",
+                    ", ".join(sorted(list(jschema['properties'].keys()))), ")"])
+
+        self.__doc__ = self._class_docstring_temp + method_desc
+        inspect.cleandoc(self)


### PR DESCRIPTION
I've updated the collection-generator to cover at least a prototype of dynamic docstrings for the dynamically compiled schema methods. 

Possible already now (code example snippets):
```python
# initiate class instance
test = CollectionGenerator('v1.0', 'test')
# print docstr for class instance 
# (incl. all dynamically built schema methods + arguments)
print(test.__doc__) 
# print docstr for schema method 
# (incl. all dynamically built instructions for a the schema method)
help(test.schemas.CORE_PERSON) # prints 
# returns MINDS 'conform' dict of a schema
lz = test.schemas.CORE_PERSON(
    at_type="https://schema.hbp/minds/Person",
    at_id="minds/core/person/v1.0.0/ze-ly.json",
    name="Ze, Ly",
    shortName="Ze, L.")
```
I want to push this to the main repo, because it might be already useful for others.

Missing (work in progress):
+ helper functions for validating / storeing collection
+ helper function for building collection?
