### PR TITLE
Make labels compatible with existing terminologies

### DIFF
--- a/v3.0/core/dataset.schema.json
+++ b/v3.0/core/dataset.schema.json
@@ -93,7 +93,7 @@
         {"$ref": "https://schema.hbp.eu/minds3.0/core/funding.schema.json"}
       ]
     },
-    "isNewVersionOf": {
+    "wasRevisionOf": {
       "description": "Link to previously released version of this dataset.",
       "oneOf": [
         {"$ref": "https://schema.hbp.eu/minds3.0/core/dataset.schema.json"}
@@ -126,7 +126,7 @@
         ]
       }
     },
-    "isBasedOn": {
+    "wasDerivedFrom": {
       "type": "array",
       "description": "Lists the publications/sources from which this content is derived or from which it is a modification or adaption.",
       "items": {

--- a/v3.0/core/model.schema.json
+++ b/v3.0/core/model.schema.json
@@ -95,7 +95,7 @@
         "$ref": "https://schema.hbp.eu/minds3.0/core/fundingInfo.schema.json"
       }
     },
-    "isNewVersionOf": {
+    "wasRevisionOf": {
       "description": "Inicates that this resource is a new edition (modified or updated) of a previously released resource.",
       "$ref": "https://schema.hbp.eu/minds3.0/core/model.schema.json"
     },

--- a/v3.0/core/studyTarget
+++ b/v3.0/core/studyTarget
@@ -48,7 +48,7 @@
         ]
       }
     },
-    "isPartof": {
+    "isPartOf": {
       "type": "array",
       "description": "Links to method(s)/paradigm(s) which produced this file (set).",
       "items": {


### PR DESCRIPTION
This is not intended to be merged (at least not yet), but is intended as a discussion point.

In the interests of making openMINDS as interoperable as possible with other semantic databases,  I guess we agree we should re-use existing terminologies as much as possible.

I've made a first pass for terms that seem similar to terms in [W3C PROV](https://www.w3.org/TR/prov-o/).