### PR TITLE
Make links to renamed "technique" schema consistent

### DIFF
--- a/v3.0/core/dataset.schema.json
+++ b/v3.0/core/dataset.schema.json
@@ -133,11 +133,11 @@
         "$ref": "https://schema.hbp.eu/minds3.0/core/publicationOrSource.schema.json"
       }
     },
-    "usedMethodsAndOrParadigms": {
+    "usedTechniques": {
       "type": "array",
       "description": "Lists the methods and/or paradigms used to produce this content.",
       "items": {
-        "$ref": "https://schema.hbp.eu/minds3.0/core/methodsOrParadigms.schema.json"
+        "$ref": "https://schema.hbp.eu/minds3.0/core/technique.schema.json"
       }
     }
   }

--- a/v3.0/core/file.schema.json
+++ b/v3.0/core/file.schema.json
@@ -65,7 +65,7 @@
       "description": "Links to method(s)/paradigm(s) in which this file (set) was used.",
       "items": {
         "anyOf": [
-          {"$ref": "https://schema.hbp.eu/minds3.0/core/methodOrParadigm.schema.json"}
+          {"$ref": "https://schema.hbp.eu/minds3.0/core/technique.schema.json"}
         ]
       }
     },
@@ -74,7 +74,7 @@
       "description": "Links to method(s)/paradigm(s) which produced this file (set).",
       "items": {
         "anyOf": [
-          {"$ref": "https://schema.hbp.eu/minds3.0/core/methodOrParadigm.schema.json"}
+          {"$ref": "https://schema.hbp.eu/minds3.0/core/technique.schema.json"}
         ]
       }
     },

--- a/v3.0/core/model.schema.json
+++ b/v3.0/core/model.schema.json
@@ -143,11 +143,11 @@
         "$ref": "https://schema.hbp.eu/minds3.0/core/publicationOrSource.schema.json"
       }
     },
-    "usedMethodsAndOrParadigms": {
+    "usedTechniques": {
       "type": "array",
       "description": "Lists the method(s) and/or paradigm(s) used to produce the content of the resource.",
       "items": {
-        "$ref": "https://schema.hbp.eu/minds3.0/core/methodsOrParadigms.schema.json"
+        "$ref": "https://schema.hbp.eu/minds3.0/core/technique.schema.json"
       }
     }
   }

--- a/v3.0/core/subject.schema.json
+++ b/v3.0/core/subject.schema.json
@@ -109,7 +109,7 @@
       "description": "Links to method(s)/paradigm(s) in which the subject(s) was(were) used.",
       "items": {
         "anyOf": [
-          {"$ref": "https://schema.hbp.eu/minds3.0/core/methodOrParadigm.schema.json"}
+          {"$ref": "https://schema.hbp.eu/minds3.0/core/technique.schema.json"}
         ]
       }
     },

--- a/v3.0/core/temporalSubjectInfo.schema.json
+++ b/v3.0/core/temporalSubjectInfo.schema.json
@@ -54,7 +54,7 @@
           {"$ref": "https://schema.hbp.eu/minds3.0/core/dataset.schema.json"},
           {"$ref": "https://schema.hbp.eu/minds3.0/core/model.schema.json"},
           {"$ref": "https://schema.hbp.eu/minds3.0/core/file.schema.json"},
-          {"$ref": "https://schema.hbp.eu/minds3.0/core/methodOrParadigm.schema.json"},
+          {"$ref": "https://schema.hbp.eu/minds3.0/core/technique.schema.json"},
           {"$ref": "https://schema.hbp.eu/minds3.0/core/studyTarget.schema.json"},
           {"$ref": "https://schema.hbp.eu/minds3.0/core/publicationOrSource.schema.json"}
         ]

--- a/v3.0/core/tissueSample.schema.json
+++ b/v3.0/core/tissueSample.schema.json
@@ -73,7 +73,7 @@
       "description": "Links to method(s)/paradigm(s) in which the subject(s) was(were) used.",
       "items": {
         "anyOf": [
-          {"$ref": "https://schema.hbp.eu/minds3.0/core/methodOrParadigm.schema.json"}
+          {"$ref": "https://schema.hbp.eu/minds3.0/core/technique.schema.json"}
         ]
       }
     },


### PR DESCRIPTION
"methodOrParadigm" was renamed to "technique" in d53957c1cd3094174b4682e02a3cfbeadeae8ca9