### PR TITLE
extract contact information (e-mail)

### DIFF
--- a/schemas/actors/contactInformation.schema.tpl.json
+++ b/schemas/actors/contactInformation.schema.tpl.json
@@ -1,0 +1,13 @@
+{
+  "_type": "https://openminds.ebrains.eu/core/ContactInformation",
+  "required": [
+    "email"
+  ],
+  "properties": {
+    "email": {
+      "format": "email",
+      "type": "string",
+      "_instruction": "Enter the email address of this person."
+    }
+  }
+}

--- a/schemas/actors/person.schema.tpl.json
+++ b/schemas/actors/person.schema.tpl.json
@@ -1,7 +1,7 @@
 {
   "_type": "https://openminds.ebrains.eu/core/Person",
   "required": [
-    "email",
+    "contactInformation",
     "givenName"
   ],
   "properties": {
@@ -14,10 +14,12 @@
         "https://openminds.ebrains.eu/core/DigitalIdentifier"
       ]
     },
-    "email": {
-      "type": "string",
-      "format": "email",
-      "_instruction": "Enter the email address of this person."
+    "contactInformation": {
+      "format": "contactInformation",
+      "_instruction": "Add the contact information of this person.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/ContactInformation"
+      ]
     },
     "familyName": {
       "type": "string",


### PR DESCRIPTION
To allow to handle the access permission separately to potentially sensitive information such as "e-mail", we should extract the contact information. This instance could potentially also be extended in the future e.g. by contact-validity information (e.g. e-mail valid from, to) etc. 