### PR TITLE
Split Laterality into Handedness and Laterality

### DIFF
--- a/schemas/research/subjectGroupState.schema.tpl.json
+++ b/schemas/research/subjectGroupState.schema.tpl.json
@@ -20,7 +20,7 @@
       "uniqueItems": true,
       "_instruction": "Add the preferred hand of the subject in this state.",
       "_linkedTypes": [
-        "https://openminds.ebrains.eu/controlledTerms/Laterality"
+        "https://openminds.ebrains.eu/controlledTerms/Handedness"
       ]
     }
   }

--- a/schemas/research/subjectState.schema.tpl.json
+++ b/schemas/research/subjectState.schema.tpl.json
@@ -14,7 +14,7 @@
     "handedness": {
       "_instruction": "Add the preferred hand of the subject in this state.",
       "_linkedTypes": [
-        "https://openminds.ebrains.eu/controlledTerms/Laterality"
+        "https://openminds.ebrains.eu/controlledTerms/Handedness"
       ]
     }
   }


### PR DESCRIPTION
Based on changes in controlledTerms https://github.com/HumanBrainProject/openMINDS_controlledTerms/pull/26, the schemas that used "controlledTerms/laterality" to describe handedness, had to be changed to the new terminology "controlledTerm/handedness".
