### PR TITLE
Copyright holder + project leader update

### DIFF
--- a/schemas/data/copyright.schema.tpl.json
+++ b/schemas/data/copyright.schema.tpl.json
@@ -10,9 +10,8 @@
       "minItems": 1,
       "uniqueItems": true,
       "_instruction": "Add one or several persons or organisations that hold the copyright.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/Organization",
-        "https://openminds.ebrains.eu/core/Person"
+      "_linkedCategories": [
+         "legalPerson"
       ]
     },
     "year": {

--- a/schemas/products/project.schema.tpl.json
+++ b/schemas/products/project.schema.tpl.json
@@ -43,9 +43,8 @@
       "minItems": 1,
       "uniqueItems": true,
       "_instruction": "Add one or several project leader (person or organization).",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/Organization",
-        "https://openminds.ebrains.eu/core/Person"
+      "_linkedCategories": [
+        "legalPerson"
       ]
     },
     "shortName": {


### PR DESCRIPTION
The holder options should also point to `"_linkedCategories"` (as e.g. in core/contribution schema), shouldn't it? 

This change was based on #165 (general description of the introduction of `"_linkedCategories"`).