### PR TITLE
adding Specimen to DatasetVersion

### DIFF
--- a/schemas/products/datasetVersion.schema.tpl.json
+++ b/schemas/products/datasetVersion.schema.tpl.json
@@ -61,6 +61,18 @@
         "https://openminds.ebrains.eu/controlledTerms/Modality"
       ]
     },
+    "studiedSpecimen": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add one or several specimen (subjects and/or tissue samples) or specimen sets (subject groups and/or tissue sample collections) that were studied in this dataset.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/Subject",
+        "https://openminds.ebrains.eu/core/SubjectGroup",
+        "https://openminds.ebrains.eu/core/TissueSample",
+        "https://openminds.ebrains.eu/core/TissueSampleCollection"
+      ]
+    },
     "type": {
       "type": "array",
       "minItems": 1,


### PR DESCRIPTION
After giving it some thought (together with @olinux) it will give us more flexibility to add Specimen also directly to a DatasetVersion. 
It will on the one side allow the user a lower level of detail for registering data (that will of course not be our recommendation, but will lower the threshold for some), and on the other hand emphasizes the connection between specimen and dataset versions (which is also more intuitive for the curators I hope).