### PR TITLE
Allow 1-N protocols for a protocolExecution

### DIFF
--- a/schemas/research/protocolExecution.schema.tpl.json
+++ b/schemas/research/protocolExecution.schema.tpl.json
@@ -58,7 +58,10 @@
       ]
     },
     "protocol": {
-      "_instruction": "Add the protocol of this protocol execution.",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all protocols that were used in this protocol execution.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/Protocol"
       ]


### PR DESCRIPTION
As discussed with @lzehl 
advantages:
- mokes the model more flexible 
- enables the creation of more generic protocols that can be mix-and-matched with specifics in the execution itself 
- reduces input/output dummies (e.g. tissue samples that the researcher did not have any information about but had to add it to create a protocol execution