### PR TITLE
Update person schema

### DIFF
--- a/schemas/actors/person.schema.tpl.json
+++ b/schemas/actors/person.schema.tpl.json
@@ -8,10 +8,7 @@
   ],
   "properties": {
     "digitalIdentifier": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add one or several globally unique and persistent digital identifier for this person.",
+      "_instruction": "Add the globally unique and persistent digital identifier for this person.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/ORCID"
       ]


### PR DESCRIPTION
It doesn't really make sense to have an array for the digitalIdentifier, now that only ORCIDs are allowed. A person should not have more than one ORCID. Right?