### PR TITLE
Reassessment of BehavioralTask

### DIFF
--- a/schemas/products/datasetVersion.schema.tpl.json
+++ b/schemas/products/datasetVersion.schema.tpl.json
@@ -6,7 +6,7 @@
     "ethicsAssessment",
     "experimentalApproach",
     "license",
-    "protocol",
+    "technique",
     "type"
   ],
   "properties": {
@@ -81,15 +81,6 @@
         "https://openminds.ebrains.eu/core/License"
       ]
     },
-    "protocol": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add one or several protocols that were used in this dataset version.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/Protocol"
-      ]
-    },
     "studiedSpecimen": {
       "type": "array",
       "minItems": 1,
@@ -100,6 +91,15 @@
         "https://openminds.ebrains.eu/core/SubjectGroup",
         "https://openminds.ebrains.eu/core/TissueSample",
         "https://openminds.ebrains.eu/core/TissueSampleCollection"
+      ]
+    },
+    "technique": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add one or several techniques that were used in this dataset version.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/controlledTerms/Technique"
       ]
     },
     "type": {

--- a/schemas/products/datasetVersion.schema.tpl.json
+++ b/schemas/products/datasetVersion.schema.tpl.json
@@ -19,6 +19,15 @@
         "legalPerson"
       ]
     },
+    "behavioralTask": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add one or several behavioral tasks that were performed in this dataset version.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/BehavioralTask"
+      ]
+    },
     "digitalIdentifier": {
       "_instruction": "Add the globally unique and persistent digital identifier of this research product version.",
       "_linkedTypes": [

--- a/schemas/research/behavioralTask.schema.tpl.json
+++ b/schemas/research/behavioralTask.schema.tpl.json
@@ -1,0 +1,21 @@
+{
+  "_type": "https://openminds.ebrains.eu/core/BehavioralTask",
+  "required": [
+    "description",
+    "fullName"
+  ],
+  "properties": {
+    "description": {
+      "type": "string",
+      "_instruction": "Enter a description of this behavioral task."
+    },
+    "fullName": {
+      "type": "string",
+      "_instruction": "Enter a descriptive full name for this behavioral task."
+    },
+    "shortName": {
+      "type": "string",
+      "_instruction": "Enter a short name (alias) for this behavioral task."
+    }
+  }
+}

--- a/schemas/research/parameterSet.schema.tpl.json
+++ b/schemas/research/parameterSet.schema.tpl.json
@@ -13,7 +13,7 @@
     "relevantFor": {
       "_instruction": "Add the technique or behavioral task where this set of parameters is used in.",
       "_linkedTypes": [
-        "https://openminds.ebrains.eu/controlledTerms/BehavioralTask",
+        "https://openminds.ebrains.eu/core/BehavioralTask",
         "https://openminds.ebrains.eu/controlledTerms/Technique"
       ]
     },

--- a/schemas/research/protocol.schema.tpl.json
+++ b/schemas/research/protocol.schema.tpl.json
@@ -10,15 +10,6 @@
       "type": "string",
       "_instruction": "Enter a description of this protocol."
     },
-    "behavioralTask": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add all behavioral tasks that were executed as part of this protocol.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/controlledTerms/BehavioralTask"
-      ]
-    },
     "name": {
       "type": "string",
       "_instruction": "Enter a descriptive name for this protocol."

--- a/schemas/research/protocolExecution.schema.tpl.json
+++ b/schemas/research/protocolExecution.schema.tpl.json
@@ -7,6 +7,15 @@
     "protocol"
   ],
   "properties": {
+    "behavioralTask": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all behavioral tasks that were performed during this protocol execution.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/BehavioralTask"
+      ]
+    },
     "input": {
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/File",

--- a/schemas/research/protocolExecution.schema.tpl.json
+++ b/schemas/research/protocolExecution.schema.tpl.json
@@ -3,6 +3,7 @@
   "_extends": "research/activity.schema.tpl.json",
   "required": [
     "input",
+    "isPartOf",
     "output",
     "protocol"
   ],
@@ -24,6 +25,12 @@
         "https://openminds.ebrains.eu/core/SubjectState",
         "https://openminds.ebrains.eu/core/TissueSampleCollectionState",
         "https://openminds.ebrains.eu/core/TissueSampleState"
+      ]
+    },
+    "isPartOf": {
+      "_instruction": "Add the dataset version in which this protocol execution was conducted.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/DatasetVersion"
       ]
     },
     "output": {


### PR DESCRIPTION
Cf. #210 

1) Intro of BehavioralTask schema
For now only contains properties "fullName", "shortName", & "description".
Future: will be extended by properties linking to controlled terms that will characterize the behavioral task (in a more standardized way).

2) Remove "behavioralTask" property from Protocol schema. Protocols should be generic, but meaningful in order to be reusable across dataset versions (if possible). The BehavioralTask will be very use-case specific in most cases. For this reason its linkage should move to the ProtocolExecution.

3) Link BehavioralTask schema to ProtocolExecution schema (cf. reasons in point 2).

4) Link BehavioralTask schema to DatasetVersion schema. As for Protocols, it should be possible to link a BehavioralTask directly to the DatasetVersion without defining ProtocolExecutions. Reason: the provision of ProtocolExecutions takes time, because they define the unique linkage between input and output in a DatasetVersion. To be able to define an openMINDS "minimal" representation of what happened in a DatasetVersion without defining ProtocolExecutions, the shortcut linkage between Protocol / BehavioralTask and DatasetVersion was established. 