### PR TITLE
Intro ServiceLink schema

### DIFF
--- a/schemas/data/serviceLink.schema.tpl.json
+++ b/schemas/data/serviceLink.schema.tpl.json
@@ -1,0 +1,29 @@
+{
+  "_type": "https://openminds.ebrains.eu/core/ServiceLink",
+  "required": [
+    "dataLocation",
+    "openDataIn",
+    "service"
+  ],
+  "properties": {
+    "dataLocation": {
+      "_instruction": "Add the file or file bundle with the data that are linked to the specified service.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/File",
+        "https://openminds.ebrains.eu/core/FileBundle"
+      ]
+    },
+    "openDataIn": {
+      "_instruction": "Add the uniform resource locator (URL) to open the linked data in the specified service.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/URL"
+      ]
+    },
+    "service": {
+      "_instruction": "Add the service in which the specified data can be opened.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/controlledTerms/Service"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Main objective: provision of old atlas viewer / cmbn-navigator links for the files/file bundles. Additional requirement: adding Service to controlledTerms, incl. the corresponding instances (will follow shortly in PRs of the corresponding openMINDS repos).

Long term: service property could link to actual core/Service schema instead of controlledTerms/Service. 
It then can link to various registered services that can provide urls to open specific data (file / files) in their service.
[requirements for such a Service schema will take some discussion time, therefore the controlledTerms/Service is the most clean short term solution]