### PR TITLE
Change specimen shortcut

### DIFF
--- a/schemas/research/tissueSample.schema.tpl.json
+++ b/schemas/research/tissueSample.schema.tpl.json
@@ -7,18 +7,6 @@
     "type"
   ],
   "properties": {    
-    "descendedFrom": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add all specimen states used to produce or obtain this tissue sample.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/SubjectGroupState",
-        "https://openminds.ebrains.eu/core/SubjectState",
-        "https://openminds.ebrains.eu/core/TissueSampleCollectionState",
-        "https://openminds.ebrains.eu/core/TissueSampleState"
-      ]
-    },
     "isPartOf": {
       "type": "array",
       "minItems": 1,

--- a/schemas/research/tissueSampleCollection.schema.tpl.json
+++ b/schemas/research/tissueSampleCollection.schema.tpl.json
@@ -18,19 +18,7 @@
         "https://openminds.ebrains.eu/sands/ParcellationEntity",
         "https://openminds.ebrains.eu/sands/ParcellationEntityVersion"
       ]
-    },    
-    "descendedFrom": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add all specimen states used to produce or obtain this tissue sample collection.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/SubjectGroupState",
-        "https://openminds.ebrains.eu/core/SubjectState",
-        "https://openminds.ebrains.eu/core/TissueSampleCollectionState",
-        "https://openminds.ebrains.eu/core/TissueSampleState"
-      ]
-    },    
+    },      
     "laterality": {
       "type": "array",
       "maxItems": 2,      

--- a/schemas/research/tissueSampleCollectionState.schema.tpl.json
+++ b/schemas/research/tissueSampleCollectionState.schema.tpl.json
@@ -1,4 +1,18 @@
 {
   "_type": "https://openminds.ebrains.eu/core/TissueSampleCollectionState",
-  "_extends": "research/specimenState.schema.tpl.json"
+  "_extends": "research/specimenState.schema.tpl.json",
+  "properties": {
+    "descendedFrom": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all specimen states used to produce or obtain this tissue sample collection state.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/SubjectGroupState",
+        "https://openminds.ebrains.eu/core/SubjectState",
+        "https://openminds.ebrains.eu/core/TissueSampleCollectionState",
+        "https://openminds.ebrains.eu/core/TissueSampleState"
+      ]
+    }
+  }
 }

--- a/schemas/research/tissueSampleState.schema.tpl.json
+++ b/schemas/research/tissueSampleState.schema.tpl.json
@@ -1,4 +1,18 @@
 {
   "_type": "https://openminds.ebrains.eu/core/TissueSampleState",
-  "_extends": "research/specimenState.schema.tpl.json"
+  "_extends": "research/specimenState.schema.tpl.json",
+  "properties": {
+    "descendedFrom": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all specimen states used to produce or obtain this tissue sample state.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/SubjectGroupState",
+        "https://openminds.ebrains.eu/core/SubjectState",
+        "https://openminds.ebrains.eu/core/TissueSampleCollectionState",
+        "https://openminds.ebrains.eu/core/TissueSampleState"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
"descended from" between TissueSample(Collection)s and Subject(Group)s needs to be between specimen states not specimen.
For example, a TissueSample is extracted from a specific state of a Subject, but then is also itself in a specific state.
OR a TissueSample is cut from another TissueSample in a specific state, but then is also itself in a specific state.
(Reminder: all specimen have to have at least one state)

Would allow "reduced provenance" capture for TissueSample(Collection)States. 