### PR TITLE
Adding a schema for RRID

### DIFF
--- a/schemas/miscellaneous/RRID.jsonld
+++ b/schemas/miscellaneous/RRID.jsonld
@@ -6,7 +6,7 @@
   "properties": {
     "identifier": {
       "type": "string",
-      "pattern": "https://scicrunch.org/resolver/RRID:([A-Za-z]+)_([A-Za-z0-9_:-]+)",
+      "pattern": "https://scicrunch.org/resolver/RRID:([A-Za-z]+)[_:]([A-Za-z0-9_:-]+)",
       "_instruction": "Enter the Research Resource Identifiers (RRID) for the portal of the Resource Identification Initiative."
     }
   }

--- a/schemas/miscellaneous/RRID.jsonld
+++ b/schemas/miscellaneous/RRID.jsonld
@@ -6,6 +6,7 @@
   "properties": {
     "identifier": {
       "type": "string",
+      "pattern": "https://scicrunch.org/resolver/RRID:([A-Za-z]+)_([A-Za-z0-9_:-]+)",
       "_instruction": "Enter the Research Resource Identifiers (RRID) for the portal of the Resource Identification Initiative."
     }
   }

--- a/schemas/miscellaneous/RRID.jsonld
+++ b/schemas/miscellaneous/RRID.jsonld
@@ -7,7 +7,7 @@
     "identifier": {
       "type": "string",
       "pattern": "https://scicrunch.org/resolver/RRID:([A-Za-z]+)[_:]([A-Za-z0-9_:-]+)",
-      "_instruction": "Enter the Research Resource Identifiers (RRID) for the portal of the Resource Identification Initiative."
+      "_instruction": "Enter the resolvable Research Resource Identifiers (RRID; format: 'https://scicrunch.org/resolver/' + RRID) for the portal of the Resource Identification Initiative."
     }
   }
 }

--- a/schemas/miscellaneous/RRID.jsonld
+++ b/schemas/miscellaneous/RRID.jsonld
@@ -1,0 +1,12 @@
+{
+  "_type": "https://openminds.ebrains.eu/core/RRID",
+  "required": [
+    "identifier"
+  ],
+  "properties": {
+    "identifier": {
+      "type": "string",
+      "_instruction": "Enter the Research Resource Identifiers (RRID) for the portal of the Resource Identification Initiative."
+    }
+  }
+}


### PR DESCRIPTION
The RRID schema should extend the collection of digital identifiers that can be used across the metadata models.

@tgbugs : could you add Anita for this issue? I cannot find her GitHub name... For both of you: It would be great to actually constrain the RRID values in the schema to resolvable IRIs that lead you to the respective page of the Resource Indentification Portal. Does such an resolvable version of the RRID exist and if so could you provide the corresponding regex pattern? 