### PR TITLE
DSV "studiedSpecimen" change to "studiedSpecimenState"

### DIFF
--- a/schemas/products/datasetVersion.schema.tpl.json
+++ b/schemas/products/datasetVersion.schema.tpl.json
@@ -90,16 +90,16 @@
         "https://openminds.ebrains.eu/controlledTerms/PreparationType"
       ]
     },
-    "studiedSpecimen": {
+    "studiedSpecimenState": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add one or several specimen (subjects and/or tissue samples) or specimen sets (subject groups and/or tissue sample collections) that were studied in this dataset.",
+      "_instruction": "Add one or several specimen states (subject and/or tissue sample states) or specimen set states (subject group and/or tissue sample collection states) that were studied in this dataset.",
       "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/Subject",
-        "https://openminds.ebrains.eu/core/SubjectGroup",
-        "https://openminds.ebrains.eu/core/TissueSample",
-        "https://openminds.ebrains.eu/core/TissueSampleCollection"
+        "https://openminds.ebrains.eu/core/SubjectState",
+        "https://openminds.ebrains.eu/core/SubjectGroupState",
+        "https://openminds.ebrains.eu/core/TissueSampleState",
+        "https://openminds.ebrains.eu/core/TissueSampleCollectionState"
       ]
     },
     "technique": {


### PR DESCRIPTION
For less ambiguous linkage for specimen since a specimen could have been studied in 2 different dataset versions but in different states. With the specimen itself attached to the dataset version, it is not clear which state was the relevant one/the studied one. 