### PR TITLE
ServiceLink update related to SANDS update

### DIFF
--- a/schemas/data/serviceLink.schema.tpl.json
+++ b/schemas/data/serviceLink.schema.tpl.json
@@ -11,7 +11,7 @@
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/File",
         "https://openminds.ebrains.eu/core/FileBundle",
-        "https://openminds.ebrains.eu/sands/AtlasAnnotation"
+        "https://openminds.ebrains.eu/sands/ParcellationEntityVersion"
       ]
     },
     "name": {


### PR DESCRIPTION
see https://github.com/HumanBrainProject/openMINDS_SANDS/pull/144

AtlasAnnotation is en embeddedType (for PEVs) and can therefore not be linked elsewhere. Since atlas annotations cannot exist without parcellation entity versions, those will be linked here instead. 
NOTE: PEVs do not have to have atlas annotations. If those are the important parts for the service, some additional checks are required. 