### PR TITLE
correcting content type for blackrock ns formats

### DIFF
--- a/instances/data/contentTypes/blackrockmicrosystems.neuralsignals.1.jsonld
+++ b/instances/data/contentTypes/blackrockmicrosystems.neuralsignals.1.jsonld
@@ -8,7 +8,7 @@
 		".ns1"
 	],
 	"specification": "https://blackrockneurotech.com/research/wp-content/ifu/LB-0023-7.00_NEV_File_Format.pdf",
-	"name": "application/vnd.blackrockmicrosystems.neuralsignals",
+	"name": "application/vnd.blackrockmicrosystems.neuralsignals.1",
 	"relatedMediaType": null,
 	"synonym": [
 		"Blackrock Neural Signals 1"


### PR DESCRIPTION
The content type names are not including the number of the file endings (different content types).