### PR TITLE
fixing contentType names for Blackrock formats

### DIFF
--- a/instances/data/contentTypes/blackrockmicrosystems.neuralsignals.1.jsonld
+++ b/instances/data/contentTypes/blackrockmicrosystems.neuralsignals.1.jsonld
@@ -8,7 +8,7 @@
 		".ns1"
 	],
 	"specification": "https://blackrockneurotech.com/research/wp-content/ifu/LB-0023-7.00_NEV_File_Format.pdf",
-	"name": "application/vnd.blackrockmicrosystems.neuralsignals",
+	"name": "application/vnd.blackrockmicrosystems.neuralsignals.1",
 	"relatedMediaType": null,
 	"synonym": [
 		"Blackrock Neural Signals 1"

--- a/instances/data/contentTypes/blackrockmicrosystems.neuralsignals.2.jsonld
+++ b/instances/data/contentTypes/blackrockmicrosystems.neuralsignals.2.jsonld
@@ -8,7 +8,7 @@
 		".ns2"
 	],
 	"specification": "https://blackrockneurotech.com/research/wp-content/ifu/LB-0023-7.00_NEV_File_Format.pdf",
-	"name": "application/vnd.blackrockmicrosystems.neuralsignals",
+	"name": "application/vnd.blackrockmicrosystems.neuralsignals.2",
 	"relatedMediaType": null,
 	"synonym": [
 		"Blackrock Neural Signals 2"

--- a/instances/data/contentTypes/blackrockmicrosystems.neuralsignals.3.jsonld
+++ b/instances/data/contentTypes/blackrockmicrosystems.neuralsignals.3.jsonld
@@ -8,7 +8,7 @@
 		".ns3"
 	],
 	"specification": "https://blackrockneurotech.com/research/wp-content/ifu/LB-0023-7.00_NEV_File_Format.pdf",
-	"name": "application/vnd.blackrockmicrosystems.neuralsignals",
+	"name": "application/vnd.blackrockmicrosystems.neuralsignals.3",
 	"relatedMediaType": null,
 	"synonym": [
 		"Blackrock Neural Signals 3"

--- a/instances/data/contentTypes/blackrockmicrosystems.neuralsignals.4.jsonld
+++ b/instances/data/contentTypes/blackrockmicrosystems.neuralsignals.4.jsonld
@@ -8,7 +8,7 @@
 		".ns4"
 	],
 	"specification": "https://blackrockneurotech.com/research/wp-content/ifu/LB-0023-7.00_NEV_File_Format.pdf",
-	"name": "application/vnd.blackrockmicrosystems.neuralsignals",
+	"name": "application/vnd.blackrockmicrosystems.neuralsignals.4",
 	"relatedMediaType": null,
 	"synonym": [
 		"Blackrock Neural Signals 4"

--- a/instances/data/contentTypes/blackrockmicrosystems.neuralsignals.5.jsonld
+++ b/instances/data/contentTypes/blackrockmicrosystems.neuralsignals.5.jsonld
@@ -8,7 +8,7 @@
 		".ns5"
 	],
 	"specification": "https://blackrockneurotech.com/research/wp-content/ifu/LB-0023-7.00_NEV_File_Format.pdf",
-	"name": "application/vnd.blackrockmicrosystems.neuralsignals",
+	"name": "application/vnd.blackrockmicrosystems.neuralsignals.5",
 	"relatedMediaType": null,
 	"synonym": [
 		"Blackrock Neural Signals 5"

--- a/instances/data/contentTypes/blackrockmicrosystems.neuralsignals.6.jsonld
+++ b/instances/data/contentTypes/blackrockmicrosystems.neuralsignals.6.jsonld
@@ -8,7 +8,7 @@
 		".ns6"
 	],
 	"specification": "https://blackrockneurotech.com/research/wp-content/ifu/LB-0023-7.00_NEV_File_Format.pdf",
-	"name": "application/vnd.blackrockmicrosystems.neuralsignals",
+	"name": "application/vnd.blackrockmicrosystems.neuralsignals.6",
 	"relatedMediaType": null,
 	"synonym": [
 		"Blackrock Neural Signals 6"

--- a/instances/data/contentTypes/blackrockmicrosystems.neuralsignals.7.jsonld
+++ b/instances/data/contentTypes/blackrockmicrosystems.neuralsignals.7.jsonld
@@ -8,7 +8,7 @@
 		".ns7"
 	],
 	"specification": "https://blackrockneurotech.com/research/wp-content/ifu/LB-0023-7.00_NEV_File_Format.pdf",
-	"name": "application/vnd.blackrockmicrosystems.neuralsignals",
+	"name": "application/vnd.blackrockmicrosystems.neuralsignals.7",
 	"relatedMediaType": null,
 	"synonym": [
 		"Blackrock Neural Signals 7"

--- a/instances/data/contentTypes/blackrockmicrosystems.neuralsignals.8.jsonld
+++ b/instances/data/contentTypes/blackrockmicrosystems.neuralsignals.8.jsonld
@@ -8,7 +8,7 @@
 		".ns8"
 	],
 	"specification": "https://blackrockneurotech.com/research/wp-content/ifu/LB-0023-7.00_NEV_File_Format.pdf",
-	"name": "application/vnd.blackrockmicrosystems.neuralsignals",
+	"name": "application/vnd.blackrockmicrosystems.neuralsignals.8",
 	"relatedMediaType": null,
 	"synonym": [
 		"Blackrock Neural Signals 8"

--- a/instances/data/contentTypes/blackrockmicrosystems.neuralsignals.9.jsonld
+++ b/instances/data/contentTypes/blackrockmicrosystems.neuralsignals.9.jsonld
@@ -8,7 +8,7 @@
 		".ns9"
 	],
 	"specification": "https://blackrockneurotech.com/research/wp-content/ifu/LB-0023-7.00_NEV_File_Format.pdf",
-	"name": "application/vnd.blackrockmicrosystems.neuralsignals",
+	"name": "application/vnd.blackrockmicrosystems.neuralsignals.9",
 	"relatedMediaType": null,
 	"synonym": [
 		"Blackrock Neural Signals 9"


### PR DESCRIPTION
It seems that all the Blackrock NSX formats have the wrong name (they miss the number).
This PR fixes this.