### PR TITLE
Update nifti.2.jsonld

### DIFF
--- a/instances/data/contentTypes/nifti.2.jsonld
+++ b/instances/data/contentTypes/nifti.2.jsonld
@@ -5,7 +5,10 @@
   "@id": "https://openminds.ebrains.eu/instances/contentTypes/application/vnd.nifti.2",
   "@type": "https://openminds.ebrains.eu/core/ContentType",
   "fileExtension": [
-    ".nii"
+    ".nii",
+    ".hdr",
+		".img",
+		".nii.gz",
   ],
   "name": "application/vnd.nifti.2",
   "relatedMediaType": null,

--- a/instances/data/contentTypes/nifti.2.jsonld
+++ b/instances/data/contentTypes/nifti.2.jsonld
@@ -7,8 +7,8 @@
   "fileExtension": [
     ".nii",
     ".hdr",
-		".img",
-		".nii.gz",
+    ".img",
+    ".nii.gz"
   ],
   "name": "application/vnd.nifti.2",
   "relatedMediaType": null,


### PR DESCRIPTION
I added missing file extensions according to this source: https://nifti.nimh.nih.gov/nifti-2/ tihs goes now in line with the nifti-1 contenttype