### PR TITLE
logic reassessment of file bundle groupings

### DIFF
--- a/schemas/data/fileBundle.schema.tpl.json
+++ b/schemas/data/fileBundle.schema.tpl.json
@@ -16,10 +16,11 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add all entities that played a role in the production of this file bundle.",
+      "_instruction": "Add all entities that defined which file was grouped into this file bundle.",
       "_linkedCategories": [
         "fileOrigin",
-        "studyTarget"
+        "studyTarget",
+        "coordinateSpace"
       ]
     },
     "format": {

--- a/schemas/data/fileBundle.schema.tpl.json
+++ b/schemas/data/fileBundle.schema.tpl.json
@@ -12,10 +12,14 @@
       "type": "string",
       "_instruction": "Enter a short content description for this file bundle."
     },
-    "descendedFrom": {
-      "_instruction": "Add the entity that played a role in the production of this file bundle.",
+    "groupedBy": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all entities that played a role in the production of this file bundle.",
       "_linkedCategories": [
-        "fileOrigin"
+        "fileOrigin",
+        "studyTarget"
       ]
     },
     "format": {

--- a/schemas/data/fileBundle.schema.tpl.json
+++ b/schemas/data/fileBundle.schema.tpl.json
@@ -33,7 +33,7 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add the type of grouping that was used to define this file bundle. Note that the grouping types define the schema type of instances stated in 'grouped by'.",
+      "_instruction": "Add all type of grouping that was used to define this file bundle. Note that the grouping types define the schema type of instances stated in 'grouped by'.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/controlledTerms/FileBundleGrouping"
       ]

--- a/schemas/data/fileBundle.schema.tpl.json
+++ b/schemas/data/fileBundle.schema.tpl.json
@@ -16,7 +16,7 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add all entities that defined which file was grouped into this file bundle.",
+      "_instruction": "Add all entities that defined which file was grouped into this file bundle. Note that the schema types of instances stated here, need to match the once stated under 'grouping type'.",
       "_linkedCategories": [
         "fileOrigin",
         "studyTarget",
@@ -30,7 +30,10 @@
       ]
     },
     "groupingType": {
-      "_instruction": "Add the type of grouping that was used to define this file bundle.",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add the type of grouping that was used to define this file bundle. Note that the grouping types define the schema type of instances stated in 'grouped by'.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/controlledTerms/FileBundleGrouping"
       ]

--- a/schemas/data/filePathPattern.schema.tpl.json
+++ b/schemas/data/filePathPattern.schema.tpl.json
@@ -6,6 +6,9 @@
   ],
   "properties": {
     "groupingType": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
       "_instruction": "Add the type of grouping that is defined by the given file path pattern.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/controlledTerms/FileBundleGrouping"
@@ -16,7 +19,7 @@
       "_formats": [
         "ECMA262"
       ],
-      "_instruction": "Enter the regular expression that defines this file path pattern."
+      "_instruction": "Enter the regular expression that defines this file path pattern. Note that the number of groups within the regular expression needs to match the number of stated grouping types."
     }
   }
 }


### PR DESCRIPTION
The content of a file bundle is defined by a file path pattern.

The file path pattern defines the overall grouping mechanism (grouping type).
@olinux : there is a graph dependency here, because the grouping type of the file path pattern has to match the one of the file bundle.

Assuming that "study target" was selected as grouping type.
The old "descendedFrom" property does not allow any further specifications regarding study targets.

To include them, I changed the property name to "groupedBy" (to better fit sementically) and added the studyTarget as linked category. 

In addition, I changed the "groupedBy" property back to be an array. Based on how the file bundles are generated, they could be based on multiple entities of the same grouping type. This is particularly true for study targets (e.g., study target grouping could be based on specific area + cell type).
@olinux this includes again a graph validation: in "groupedBy" only entities are allowed of the specified grouping type.

To go even further (and becoming more flexible): the grouping type could be an array as well, allowing to create file bundles that could be grouped by e.g. a subject and a study target. 

@HumanBrainProject/openminds-developers what do you think? I will adopt this PR draft based on our discussion.