### PR TITLE
Update contentType.schema.tpl.json with displayLabel

### DIFF
--- a/schemas/data/contentType.schema.tpl.json
+++ b/schemas/data/contentType.schema.tpl.json
@@ -4,6 +4,10 @@
     "name"  
   ],
   "properties": {
+    "displayLabel": {
+      "type": "string",
+      "_instruction": "Enter a display label for this content type."
+    },
     "fileExtension": {
       "type": "array",
       "minItems": 1,


### PR DESCRIPTION
The names of the contentTypes are highly accurate but also highly technical and sometimes quite long. 
For better display in service systems such as the KG Search I suggest to add a (optional) displayLabel property.