### PR TITLE
Update strain.schema.tpl.json

### DIFF
--- a/schemas/research/strain.schema.tpl.json
+++ b/schemas/research/strain.schema.tpl.json
@@ -2,7 +2,8 @@
   "_type": "https://openminds.ebrains.eu/core/Strain",
   "required": [
     "geneticStrainType",
-    "name"
+    "name",
+    "species"
   ],
   "properties": {
     "backgroundStrain": {


### PR DESCRIPTION
Just noticed that "species" in the strain schema was optional. Checked the closed issues and such, but there we discussed that this needs to be required because specimen can either choose CT/species or core/strain as "species", but the species information must be there (either directly or via strain schema and then species).