### PR TITLE
Allow use of ServiceLink for LivePaperResourceItems

### DIFF
--- a/schemas/data/serviceLink.schema.tpl.json
+++ b/schemas/data/serviceLink.schema.tpl.json
@@ -12,7 +12,8 @@
         "https://openminds.ebrains.eu/core/File",
         "https://openminds.ebrains.eu/core/FileArchive",
         "https://openminds.ebrains.eu/core/FileBundle",
-        "https://openminds.ebrains.eu/sands/ParcellationEntityVersion"
+        "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
+        "https://openminds.ebrains.eu/publications/LivePaperResourceItem"
       ]
     },
     "name": {


### PR DESCRIPTION
As discussed on Slack.

Longer term, a more elegant solution which avoids having the explicit dependency from the core module to the publications module might be to introduce a new _linkedCategory called something like "dataLocation".