### PR TITLE
ServiceLink from ModelVersion

### DIFF
--- a/schemas/data/serviceLink.schema.tpl.json
+++ b/schemas/data/serviceLink.schema.tpl.json
@@ -7,11 +7,12 @@
   ],
   "properties": {
     "dataLocation": {
-      "_instruction": "Add the file, file bundle, or atlas annotatation with the data that are linked to the specified service.",
+      "_instruction": "Add the file, file bundle, atlas annotatation, or other entity with the data that are linked to the specified service.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/File",
         "https://openminds.ebrains.eu/core/FileArchive",
         "https://openminds.ebrains.eu/core/FileBundle",
+        "https://openminds.ebrains.eu/core/ModelVersion",
         "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
         "https://openminds.ebrains.eu/publications/LivePaperResourceItem"
       ]


### PR DESCRIPTION
The reasons for adding this rather than just using a ServiceLink from a File containing the model code is that:

1. ModelVersion only has the "repository" property, which often points to a URL outside EBRAINS (e.g. Github, ModelDB), for which individual Files are not indexed.
2. The ServiceLink URL can depend on multiple files, e.g. the inputData as well as the code.