### PR TITLE
ModelVersion format array

### DIFF
--- a/schemas/products/modelVersion.schema.tpl.json
+++ b/schemas/products/modelVersion.schema.tpl.json
@@ -23,11 +23,14 @@
       ]
     },
     "format": {
-      "_instruction": "Add the used content type of this model version.",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add the content types used in this model version.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/ContentType"
       ]
-    },    
+    },
     "inputData": {
       "type": "array",
       "minItems": 1,


### PR DESCRIPTION
allow ModelVersion.format to contain multiple content types, e.g. NEURON models typically consist of both Hoc and NMODL files