### PR TITLE
Clean up: experimental activity

### DIFF
--- a/schemas/research/experimentalActivity.schema.tpl.json
+++ b/schemas/research/experimentalActivity.schema.tpl.json
@@ -1,5 +1,4 @@
 {
-  "_type": "https://openminds.ebrains.eu/core/ExperimentalActivity",
   "_extends": "research/activity.schema.tpl.json",
   "required": [
     "isPartOf",
@@ -13,7 +12,7 @@
       ]
     },
     "preparationDesign": {
-      "_instruction": "Add the initial preparation type for this experimental activity.",
+      "_instruction": "Add the initial preparation type for this activity.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/controlledTerms/PreparationType"
       ]
@@ -22,7 +21,7 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add all protocols that were used in this experimental activity.",
+      "_instruction": "Add all protocols used during this experimental activity.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/Protocol"
       ]

--- a/schemas/research/experimentalActivity.schema.tpl.json
+++ b/schemas/research/experimentalActivity.schema.tpl.json
@@ -6,7 +6,7 @@
   ],
   "properties": {
     "isPartOf": {
-      "_instruction": "Add the dataset version in which this experimental activity was conducted.",
+      "_instruction": "Add the dataset version in which this activity was conducted.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/DatasetVersion"
       ]
@@ -21,7 +21,7 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add all protocols used during this experimental activity.",
+      "_instruction": "Add all protocols used during this activity.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/Protocol"
       ]


### PR DESCRIPTION
MINOR changes:
- improved instructions

MAJOR changes:
- removed `_type` from the schema because concept schemas do not have a type and (as far as I am aware) can only be extended if they do not have a type themselves, correct @lzehl? This schema is extended a lot of times (e.g., specimenPrep/devicePlacement)

SPECIAL ATTENTION:
none

