### PR TITLE
Clean up: custom property set

### DIFF
--- a/schemas/research/customPropertySet.schema.tpl.json
+++ b/schemas/research/customPropertySet.schema.tpl.json
@@ -2,26 +2,26 @@
   "_type": "https://openminds.ebrains.eu/core/CustomPropertySet",
   "required": [
     "context",
-    "relevantFor",
-    "definedIn"
+    "dataLocation",    
+    "relevantFor"
   ],
   "properties": {
     "context": {
       "type": "string",
       "_instruction": "Enter the common context for this custom property set."
     },
+    "dataLocation": {
+      "_instruction": "Add the location of the data that define the custom property set for the given context (e.g., stored as file or other entities such as property-value lists).",
+      "_linkedTypes": [        
+        "https://openminds.ebrains.eu/core/Configuration",
+        "https://openminds.ebrains.eu/core/File",
+        "https://openminds.ebrains.eu/core/PropertyValueList"
+      ]
+    },
     "relevantFor": {
       "_instruction": "Add the technique for which this custom property set is relevant.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/controlledTerms/Technique"
-      ]
-    },
-    "definedIn": {
-      "_instruction": "Add a file or configuration that specifies the custom property set of the given context.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/File",
-        "https://openminds.ebrains.eu/core/Configuration",
-        "https://openminds.ebrains.eu/core/PropertyValueList"
       ]
     }
   }

--- a/schemas/research/customPropertySet.schema.tpl.json
+++ b/schemas/research/customPropertySet.schema.tpl.json
@@ -20,8 +20,8 @@
     },
     "relevantFor": {
       "_instruction": "Add the technique for which this custom property set is relevant.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/controlledTerms/Technique"
+      "_linkedCategories": [
+        "technique"
       ]
     }
   }


### PR DESCRIPTION
MINOR changes:
- improved instructions
- establish alphabetical order
- renamed `definedIn` with `dataLocation`, which merges two existing properties which were used in approx. the same way; details of what data is found there or how the data is stored, should be stated in the instructions

MAJOR changes:
none

SPECIAL ATTENTION:
none

CHANGELOG:
- replaced link to technique for `relevantFor` with new category `technique` (which includes techniques, analysisTechniques and stimulationTechniques); see https://github.com/HumanBrainProject/openMINDS_controlledTerms/pull/393

