### PR TITLE
Clean up: file repository

### DIFF
--- a/schemas/data/fileRepository.schema.tpl.json
+++ b/schemas/data/fileRepository.schema.tpl.json
@@ -7,7 +7,7 @@
   ],
   "properties": {
     "format": {
-      "_instruction": "If the files and file bundles within this repository are organised and formatted according to a formal data structure, add the content type of this file repository. Leave blank if no formal data structure has been applied to the files and file bundles within this repository.",
+      "_instruction": "If the files and file bundles within this repository are organised and formatted according to a formal data structure, add the content type of this formal data structure. Leave blank if no formal data structure has been applied.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/ContentType"
       ]
@@ -35,7 +35,7 @@
       "type": "string",
       "_instruction": "Enter the name of this file repository."
     },    
-    "pattern": {
+    "contentTypePattern": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,

--- a/schemas/data/fileRepository.schema.tpl.json
+++ b/schemas/data/fileRepository.schema.tpl.json
@@ -6,17 +6,8 @@
     "name"
   ],
   "properties": {
-    "contentTypePattern": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add all content type patterns that would identify matching content types for files within this file repository.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/ContentTypePattern"
-      ]
-    },
     "format": {
-      "_instruction": "If file instances and bundles within the repository are organized and formatted according to a formal data structure use the appropriate contentType. Leave blank otherwise.",
+      "_instruction": "If the files and file bundles within this repository are organised and formatted according to a formal data structure, add the content type of this file repository. Leave blank if no formal data structure has been applied to the files and file bundles within this repository.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/ContentType"
       ]
@@ -28,7 +19,7 @@
       ]
     },
     "hostedBy": {
-      "_instruction": "Add the host of this file repository.",
+      "_instruction": "Add the host organization of this file repository.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/Organization"
       ]
@@ -38,28 +29,37 @@
       "_formats": [
         "iri"
       ],
-      "_instruction": "Enter the internationalized resource identifier (IRI) of this file repository."
+      "_instruction": "Enter the internationalized resource identifier (IRI) to this file repository."
     },
     "name": {
       "type": "string",
       "_instruction": "Enter the name of this file repository."
-    },
-    "repositoryType": {
-      "_instruction": "Add the type of this file repository.",
+    },    
+    "pattern": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all content type patterns that identify matching content types for files within this file repository.",
       "_linkedTypes": [
-        "https://openminds.ebrains.eu/controlledTerms/FileRepositoryType"
+        "https://openminds.ebrains.eu/core/ContentTypePattern"
       ]
     },
     "storageSize": {
-      "_instruction": "Enter the storage size this file repository allocates.",
+      "_instruction": "Enter the storage size of this file repository.",
       "_embeddedTypes": [
         "https://openminds.ebrains.eu/core/QuantitativeValue"
       ]
     },
     "structurePattern": {
-      "_instruction": "Add a file repository structure which identifies the file path patterns used in this file repository.",
+      "_instruction": "Add the file repository structure that identifies the file path patterns used in this file repository.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/FileRepositoryStructure"
+      ]
+    },    
+    "type": {
+      "_instruction": "Add the type of this file repository.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/controlledTerms/FileRepositoryType"
       ]
     }
   }


### PR DESCRIPTION
MINOR changes:
- improved instructions
- establish alphabetical order
- renamed `repositoryType` to `type` to reduce list of property names and because we decided to use type when the specific context is explicit
- renamed `contentTypePattern` to `pattern` to adhere to new convention s stated above (generally: when the more generic property name makes sense in the context of the schema, this should be used)

MAJOR changes:
none

SPECIAL ATTENTION:
none