### PR TITLE
Clean up: model version

### DIFF
--- a/schemas/products/modelVersion.schema.tpl.json
+++ b/schemas/products/modelVersion.schema.tpl.json
@@ -2,8 +2,8 @@
   "_type": "https://openminds.ebrains.eu/core/ModelVersion",
   "_extends": "products/researchProductVersion.schema.tpl.json",
   "required": [
-    "license",
-    "format"
+    "format",
+    "license"
   ],
   "properties": {
     "developer": {

--- a/schemas/products/modelVersion.schema.tpl.json
+++ b/schemas/products/modelVersion.schema.tpl.json
@@ -70,11 +70,11 @@
         "https://openminds.ebrains.eu/core/WebResource"
       ]
     },    
-    "usedFormat": {
+    "format": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add all used content types of this computational model version.",
+      "_instruction": "Add all content types of the files composing this computational model version.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/ContentType"
       ]

--- a/schemas/products/modelVersion.schema.tpl.json
+++ b/schemas/products/modelVersion.schema.tpl.json
@@ -2,15 +2,15 @@
   "_type": "https://openminds.ebrains.eu/core/ModelVersion",
   "_extends": "products/researchProductVersion.schema.tpl.json",
   "required": [
-    "format",
-    "license"
+    "license",
+    "usedFormat"
   ],
   "properties": {
     "developer": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "If necessary, add one or several developers (person or organization) that contributed to the code implementation of this model version. Note that these developers will overwrite the once provided in the model product this version belongs to.",
+      "_instruction": "Add all parties that developed this computational model version. Note that these developers will overwrite the developer list provided for the overarching computational model.",
       "_linkedCategories": [
         "legalPerson"
       ]
@@ -22,20 +22,11 @@
         "https://openminds.ebrains.eu/core/SWHID"
       ]
     },
-    "format": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add the content types used in this model version.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/ContentType"
-      ]
-    },
     "inputData": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add the data that was used as input for this model version.",
+      "_instruction": "Add the data that was used as input for this computational model version.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/DOI",
         "https://openminds.ebrains.eu/core/File",
@@ -47,13 +38,13 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add all model versions that can be used alternatively to this model version.",
+      "_instruction": "Add all computational model versions that can be used alternatively to this computational model version.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/ModelVersion"
       ]
     },
     "isNewVersionOf": {
-      "_instruction": "Add the model version preceding this model version.",
+      "_instruction": "Add the computational model version preceding this computational model version.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/ModelVersion"
       ]
@@ -62,7 +53,7 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add at least one license for this model version.",
+      "_instruction": "Add all licenses of this computational model version.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/License"
       ]
@@ -71,12 +62,21 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add the data that was generated as output of this model version.",
+      "_instruction": "Add the data that was generated as output for this computational model version.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/DOI",
         "https://openminds.ebrains.eu/core/File",
         "https://openminds.ebrains.eu/core/FileBundle",
         "https://openminds.ebrains.eu/core/URL"
+      ]
+    },    
+    "usedFormat": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all used content types of this computational model version.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/ContentType"
       ]
     }
   }

--- a/schemas/products/modelVersion.schema.tpl.json
+++ b/schemas/products/modelVersion.schema.tpl.json
@@ -26,7 +26,7 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add all content types of the files composing this computational model version.",
+      "_instruction": "Add the content type of this computational model version, or the content types of the files composing the model version.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/ContentType"
       ]
@@ -71,7 +71,7 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add the data that was generated as output for this computational model version.",
+      "_instruction": "Add the data that was generated as output by this computational model version.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/DOI",
         "https://openminds.ebrains.eu/core/File",

--- a/schemas/products/modelVersion.schema.tpl.json
+++ b/schemas/products/modelVersion.schema.tpl.json
@@ -3,7 +3,7 @@
   "_extends": "products/researchProductVersion.schema.tpl.json",
   "required": [
     "license",
-    "usedFormat"
+    "format"
   ],
   "properties": {
     "developer": {
@@ -20,6 +20,15 @@
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/DOI",
         "https://openminds.ebrains.eu/core/SWHID"
+      ]
+    },
+    "format": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all content types of the files composing this computational model version.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/ContentType"
       ]
     },
     "inputData": {
@@ -68,15 +77,6 @@
         "https://openminds.ebrains.eu/core/File",
         "https://openminds.ebrains.eu/core/FileBundle",
         "https://openminds.ebrains.eu/core/WebResource"
-      ]
-    },    
-    "format": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add all content types of the files composing this computational model version.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/ContentType"
       ]
     }
   }

--- a/schemas/products/modelVersion.schema.tpl.json
+++ b/schemas/products/modelVersion.schema.tpl.json
@@ -31,7 +31,7 @@
         "https://openminds.ebrains.eu/core/DOI",
         "https://openminds.ebrains.eu/core/File",
         "https://openminds.ebrains.eu/core/FileBundle",
-        "https://openminds.ebrains.eu/core/URL"
+        "https://openminds.ebrains.eu/core/WebResource"
       ]
     },
     "isAlternativeVersionOf": {
@@ -67,7 +67,7 @@
         "https://openminds.ebrains.eu/core/DOI",
         "https://openminds.ebrains.eu/core/File",
         "https://openminds.ebrains.eu/core/FileBundle",
-        "https://openminds.ebrains.eu/core/URL"
+        "https://openminds.ebrains.eu/core/WebResource"
       ]
     },    
     "usedFormat": {


### PR DESCRIPTION
MINOR changes:
- improved instructions

MAJOR changes:
none

SPECIAL ATTENTION:
- renamed `format` to `usedFormat`: because format has been used to express the format of the type of schema, e.g. file has a format with instructions to add the content type OF the file, here the instructions ask for USED content types

CHANGELOG:
- `inputData` & `outputData` link to `WebResource` instead of `URL`