### PR TITLE
Clean up: ORCID

### DIFF
--- a/schemas/digitalIdentifier/ORCID.schema.tpl.json
+++ b/schemas/digitalIdentifier/ORCID.schema.tpl.json
@@ -7,7 +7,7 @@
     "identifier": {
       "type": "string",
       "pattern": "^https:\/\/orcid.org\/[0-9]{4}-[0-9]{4}-[0-9]{4}-([0-9]{3}[A-Z]|[0-9]{4})$",
-      "_instruction": "Enter the resolvable identifier (IRI) of the Open Researcher and Contributor ID, Inc."
+      "_instruction": "Enter the identifier for researchers provided by the Open Researcher and Contributor ID, Inc. (ORCID) as an internationalized resource identifier (IRI) following the defined pattern (i.e., 'https://orcid.org/' + ORCID)."
     }
   }
 }

--- a/schemas/digitalIdentifier/ORCID.schema.tpl.json
+++ b/schemas/digitalIdentifier/ORCID.schema.tpl.json
@@ -7,7 +7,7 @@
     "identifier": {
       "type": "string",
       "pattern": "^https:\/\/orcid.org\/[0-9]{4}-[0-9]{4}-[0-9]{4}-([0-9]{3}[A-Z]|[0-9]{4})$",
-      "_instruction": "Enter the identifier for researchers provided by the Open Researcher and Contributor ID, Inc. (ORCID) as an internationalized resource identifier (IRI) following the defined pattern (i.e., 'https://orcid.org/' + ORCID)."
+      "_instruction": "Enter the identifier for researchers provided by Open Researcher and Contributor ID, Inc. (ORCID, Inc.) as an internationalized resource identifier (IRI) following the defined pattern (i.e., 'https://orcid.org/' + ORCID)."
     }
   }
 }


### PR DESCRIPTION
MINOR changes:
- improved instructions
- (re)moved schema from miscellaneous to new folder called digitalIdentifier for better grouping and decluttering of the miscellaneous folder

MAJOR changes:
none

SPECIAL ATTENTION:
none
