### PR TITLE
Clean up: protocol execution

### DIFF
--- a/schemas/research/protocolExecution.schema.tpl.json
+++ b/schemas/research/protocolExecution.schema.tpl.json
@@ -1,12 +1,6 @@
 {
   "_type": "https://openminds.ebrains.eu/core/ProtocolExecution",
-  "_extends": "research/activity.schema.tpl.json",
-  "required": [
-    "input",
-    "isPartOf",
-    "output",
-    "protocol"
-  ],
+  "_extends": "research/experimentalActivity.schema.tpl.json",
   "properties": {
     "behavioralProtocol": {
       "type": "array",
@@ -27,12 +21,6 @@
         "https://openminds.ebrains.eu/core/TissueSampleState"
       ]
     },
-    "isPartOf": {
-      "_instruction": "Add the dataset version in which this protocol execution was conducted.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/DatasetVersion"
-      ]
-    },
     "output": {
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/File",
@@ -41,21 +29,6 @@
         "https://openminds.ebrains.eu/core/SubjectState",
         "https://openminds.ebrains.eu/core/TissueSampleCollectionState",
         "https://openminds.ebrains.eu/core/TissueSampleState"
-      ]
-    },
-    "preparationDesign": {
-      "_instruction": "Add the initial preparation type for this protocol execution.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/controlledTerms/PreparationType"
-      ]
-    },
-    "protocol": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add all protocols that were used in this protocol execution.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/Protocol"
       ]
     }
   }

--- a/schemas/research/protocolExecution.schema.tpl.json
+++ b/schemas/research/protocolExecution.schema.tpl.json
@@ -18,7 +18,9 @@
         "https://openminds.ebrains.eu/core/SubjectGroupState",
         "https://openminds.ebrains.eu/core/SubjectState",
         "https://openminds.ebrains.eu/core/TissueSampleCollectionState",
-        "https://openminds.ebrains.eu/core/TissueSampleState"
+        "https://openminds.ebrains.eu/core/TissueSampleState",
+        "https://openminds.ebrains.eu/sands/BrainAtlasVersion",
+        "https://openminds.ebrains.eu/sands/CommonCoordinateSpaceVersion"
       ]
     },
     "output": {


### PR DESCRIPTION
MINOR changes:
none

MAJOR changes:
- replace `"_extends": ["activity"]` with `"_extends": ["experimentalActivity"]` which has most of the properties that were asked for, except for `behavioralProtocol`

SPECIAL ATTENTION:
none

CHANGELOG:
- added `CommonCoordinateSpaceVersion` and `BrainAtlasVersion` as allowed `input`; discussed offline in relation to other updates and it made sense to add it here as well
