### PR TITLE
Clean up: subject group

### DIFF
--- a/schemas/research/subjectGroup.schema.tpl.json
+++ b/schemas/research/subjectGroup.schema.tpl.json
@@ -4,7 +4,12 @@
   "required": [
     "studiedState"
   ],
-  "properties": {
+  "properties": {    
+    "numberOfSubjects": {
+      "type": "integer",
+      "minimum": 2,
+      "_instruction": "Enter the number of subjects that belong to this subject group."
+    },
     "studiedState": {
       "type": "array",
       "minItems": 1,


### PR DESCRIPTION
MINOR changes:
- improved instructions

MAJOR changes:
none

SPECIAL ATTENTION:
- (re)moved former `quantity` from concept schema with a more specific property name to subjectGroup schema (as `numberOfSubjects`)
- added a `minimum` for the integer range so that it is not possible to state anything below 2 as the number of subjects 
