### PR TITLE
Clean up: SWHID

### DIFF
--- a/schemas/digitalIdentifier/SWHID.schema.tpl.json
+++ b/schemas/digitalIdentifier/SWHID.schema.tpl.json
@@ -7,7 +7,7 @@
     "identifier": {
       "type": "string",
       "pattern": "^https:\/\/archive.softwareheritage.org\/swh:1:(cnt|dir|rel|rev|snp):[0-9a-f]{40}(;(origin|visit|anchor|path|lines)=[^ \t\r\n\f]+)*$",
-      "_instruction": "Enter the resolvable identifier (IRI) of the Software Heritage archive."
+      "_instruction": "Enter the identifier for software source code artefacts provided by the Software Heritage archive ('SoftWare Heritage persistent IDentifier'; SWHID) as an internationalized resource identifier (IRI) following the defined pattern (i.e., 'https://archive.softwareheritage.org/' + SWHID)."
     }
   }
 }


### PR DESCRIPTION
MINOR changes:
- improved instructions
- (re)moved schema from miscellaneous to new folder called digitalIdentifier for better grouping and decluttering of the miscellaneous folder

MAJOR changes:
none

SPECIAL ATTENTION:
none

