### PR TITLE
Clean up: tissue sample

### DIFF
--- a/schemas/research/tissueSample.schema.tpl.json
+++ b/schemas/research/tissueSample.schema.tpl.json
@@ -11,7 +11,7 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add all anatomical entities that describe the visible anatomy of this tissue sample.",    
+      "_instruction": "Add all anatomical entities that describe the anatomical location of this tissue sample.",    
       "_linkedCategories": [
         "anatomicalLocation"
       ]

--- a/schemas/research/tissueSample.schema.tpl.json
+++ b/schemas/research/tissueSample.schema.tpl.json
@@ -20,7 +20,7 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add all tissue sample collections of which this tissue sample is part of.",
+      "_instruction": "Add all tissue sample collections this tissue sample is part of.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/TissueSampleCollection"
       ]

--- a/schemas/research/tissueSample.schema.tpl.json
+++ b/schemas/research/tissueSample.schema.tpl.json
@@ -6,7 +6,16 @@
     "studiedState",
     "type"
   ],
-  "properties": {    
+  "properties": {        
+    "anatomicalLocation": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all anatomical entities that describe the visible anatomy of this tissue sample.",    
+      "_linkedCategories": [
+        "anatomicalLocation"
+      ]
+    },
     "isPartOf": {
       "type": "array",
       "minItems": 1,
@@ -21,7 +30,7 @@
       "maxItems": 2,
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add one or both hemisphere sides from which this tissue sample originates from.",
+      "_instruction": "Add one or both sides of the body, bilateral organ or bilateral organ part that this tissue sample originates from.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/controlledTerms/Laterality"
       ]
@@ -41,20 +50,6 @@
       "_instruction": "Add all states in which this tissue sample was studied.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/TissueSampleState"
-      ]
-    },
-    "anatomicalLocation": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add all anatomical entities to which this tissue sample belongs.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",        
-        "https://openminds.ebrains.eu/controlledTerms/OrganismSubstance",
-        "https://openminds.ebrains.eu/controlledTerms/Organ",
-        "https://openminds.ebrains.eu/sands/CustomAnatomicalEntity",
-        "https://openminds.ebrains.eu/sands/ParcellationEntity",
-        "https://openminds.ebrains.eu/sands/ParcellationEntityVersion"
       ]
     },
     "type": {


### PR DESCRIPTION
MINOR changes:
- improved instructions
- establish alphabetical order

MAJOR changes:
none

SPECIAL ATTENTION:
- replaced linked schemas for `anatomicalLocation` by a new category called `anatomicalLocation` (Note: Category not added to the schemas yet, but the following schemas will receive this category:
     - sands/CustomAnatomicalEntity
     - sands/ParcellationEntity
     - sands/ParcellationEntityVersion
     - controlledTerms/Organ
     - controlledTerms/OrganismSubstance
     - controlledTerms/UBERONParcellation
     - controlledTerms/SubcellularEntity)
