### PR TITLE
Clean up: tissue sample collection

### DIFF
--- a/schemas/research/tissueSampleCollection.schema.tpl.json
+++ b/schemas/research/tissueSampleCollection.schema.tpl.json
@@ -11,7 +11,7 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add all anatomical entities that describe the visible anatomy of this tissue sample collection.",    
+      "_instruction": "Add all anatomical entities that describe the anatomical location of this tissue sample collection.",    
       "_linkedCategories": [
         "anatomicalLocation"
       ]

--- a/schemas/research/tissueSampleCollection.schema.tpl.json
+++ b/schemas/research/tissueSampleCollection.schema.tpl.json
@@ -11,25 +11,25 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add all anatomical entities to which this tissue sample belongs.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-        "https://openminds.ebrains.eu/controlledTerms/OrganismSubstance",
-        "https://openminds.ebrains.eu/controlledTerms/Organ",
-        "https://openminds.ebrains.eu/sands/CustomAnatomicalEntity",
-        "https://openminds.ebrains.eu/sands/ParcellationEntity",
-        "https://openminds.ebrains.eu/sands/ParcellationEntityVersion"
+      "_instruction": "Add all anatomical entities that describe the visible anatomy of this tissue sample collection.",    
+      "_linkedCategories": [
+        "anatomicalLocation"
       ]
     },      
     "laterality": {
-      "type": "array",
-      "maxItems": 2,      
+      "type": "array",      
       "minItems": 1,
+      "maxItems": 2,      
       "uniqueItems": true,
-      "_instruction": "Add one or both hemisphere sides from which the tissue samples in this collection originate from.",
+      "_instruction": "Add one or both sides of the body, bilateral organ or bilateral organ part that this tissue sample collection originates from.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/controlledTerms/Laterality"
       ]
+    },    
+    "numberOfTissueSamples": {
+      "type": "integer",
+      "minimum": 2,
+      "_instruction": "Enter the number of tissue samples that belong to this tissue sample collection."
     },
     "origin": {
       "type": "array",


### PR DESCRIPTION
MINOR changes:
- improved instructions
- establish correct order within property

MAJOR changes:
none

SPECIAL ATTENTION:
- (re)moved former `quantity` from concept schema with a more specific property name to tissueSampleCollection schema (as `numberOfTissueSamples`)
- added a `minimum` for the integer range so that it is not possible to state anything below 2 as the number of tissue samples
- replaced linked schemas for `anatomicalLocation` by a new category called `anatomicalLocation` (Note: Category not added to the schemas yet, but the following schemas will receive this category:
     - sands/CustomAnatomicalEntity
     - sands/ParcellationEntity
     - sands/ParcellationEntityVersion
     - controlledTerms/Organ
     - controlledTerms/OrganismSubstance
     - controlledTerms/UBERONParcellation
     - controlledTerms/SubcellularEntity)

