### PR TITLE
Clean up: device usage

### DIFF
--- a/schemas/research/deviceUsage.schema.tpl.json
+++ b/schemas/research/deviceUsage.schema.tpl.json
@@ -1,0 +1,31 @@
+{
+  "_categories": [
+    "deviceUsage"
+  ],
+  "required": [
+    "device"
+  ],
+  "properties": { 
+    "metadataLocation": {    
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all files or file bundles containing additional information about the usage of this device.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/File",
+        "https://openminds.ebrains.eu/core/FileBundle"
+      ]
+    }, 
+    "lookupLabel": {
+      "type": "string",
+      "_instruction": "Enter a lookup label for this device usage that may help you to find this instance more easily."
+    }, 
+    "usedSpecimen": {
+      "_instruction": "Add the state of the tissue sample or subject that this device was used on.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/SubjectState",
+        "https://openminds.ebrains.eu/core/TissueSampleState"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
MINOR changes:
none

MAJOR changes:
- introduction of new concept schema for device usages (in ephys and specimenPrep repo)

SPECIAL ATTENTION:
- specific device names are replaced by generic `device` as property name (e.g. electrode schema had `electrode` to state the electrode (device) that was used)
- former `additionalInformation` renamed to `metadataLocation` to avoid potential confusions with `additionalRemarks` 
- all 3 properties are newly introduced for some of the usage schemas (`SlicingDeviceUsage` in specimenPrep repo, which had none of them)
