### PR TITLE
Multiple file hashes

### DIFF
--- a/schemas/data/file.schema.tpl.json
+++ b/schemas/data/file.schema.tpl.json
@@ -11,7 +11,7 @@
     "contentDescription": {
       "type": "string",
       "_instruction": "Enter a short content description for this file instance."
-    },    
+    },
     "dataType": {
       "type": "array",
       "minItems": 1,
@@ -34,7 +34,10 @@
       ]
     },
     "hash": {
-      "_instruction": "Add the hash that was generated for this file instance.",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all hashes that were generated for this file instance.",
       "_embeddedTypes": [
         "https://openminds.ebrains.eu/core/Hash"
       ]


### PR DESCRIPTION
we often need both MD5 (used by data proxy) and SHA-1 (used by CWL), for example.