### PR TITLE
Fix related media type for a couple of ContentType instances

### DIFF
--- a/instances/data/contentTypes/vnd.sciunit.model.jsonld
+++ b/instances/data/contentTypes/vnd.sciunit.model.jsonld
@@ -8,6 +8,6 @@
 		".py"
 	],
 	"name": "application/vnd.sciunit.model",
-	"relatedMediaType": "text/x-python.3",
+	"relatedMediaType": null,
 	"synonym": null
 }

--- a/instances/data/contentTypes/vnd.sciunit.test.jsonld
+++ b/instances/data/contentTypes/vnd.sciunit.test.jsonld
@@ -8,6 +8,6 @@
 		".py"
 	],
 	"name": "application/vnd.sciunit.test",
-	"relatedMediaType": "text/x-python.3",
+	"relatedMediaType": null,
 	"synonym": null
 }


### PR DESCRIPTION
Related media types should be IRIs, and there doesn't seem to be an official IANA page for "text/x-python"