### PR TITLE
allowing web resources as licenses for online accessible DUAs

### DIFF
--- a/schemas/products/datasetVersion.schema.tpl.json
+++ b/schemas/products/datasetVersion.schema.tpl.json
@@ -88,9 +88,10 @@
       ]
     },
     "license": {
-      "_instruction": "Add the license of this dataset version.",
+      "_instruction": "Add the license or an online available data usage agreement for this dataset version.",
       "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/License"
+        "https://openminds.ebrains.eu/core/License",
+        "https://openminds.ebrains.eu/core/WebResource"
       ]
     },
     "preparationDesign": {


### PR DESCRIPTION
For datasets this issue comes up because of GDPR since now most GDPR sensitive data do not have an officially registered license anymore but only a data usage agreement (DUA)...

Not every DUA is a registered license. And DUAs can be applied on top of licenses as well it seems. The latter point we ignore for now, but allowing WebResources for "licence" makes it possible to link to online available DUAs.