### PR TITLE
More "digitalIdentifier" options for DatasetVersions

### DIFF
--- a/schemas/products/datasetVersion.schema.tpl.json
+++ b/schemas/products/datasetVersion.schema.tpl.json
@@ -40,7 +40,8 @@
     "digitalIdentifier": {
       "_instruction": "Add the globally unique and persistent digital identifier of this research product version.",
       "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/DOI"
+        "https://openminds.ebrains.eu/core/DOI",
+        "https://openminds.ebrains.eu/core/IdentifiersDotOrgID"
       ]
     },
     "ethicsAssessment": {


### PR DESCRIPTION
adding https://openminds.ebrains.eu/core/IdentifiersDotOrgID as option for digitalIdentifier in DatasetVersion

(not sure if we can assume that for DS as well, because I'm uncertain if Identifier.org, supports the concept of identifier versioning)