### PR TITLE
Update softwareVersion.schema.tpl.json

### DIFF
--- a/schemas/products/softwareVersion.schema.tpl.json
+++ b/schemas/products/softwareVersion.schema.tpl.json
@@ -144,6 +144,17 @@
       "items": {
         "type": "string"
       }
-    }
+    },
+    "supportedConstruct":{
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all constructs (e.g., brain atlas version or model version) that are supported by this software version.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/ModelVersion",
+        "https://openminds.ebrains.eu/sands/BrainAtlasVersion",
+        "https://openminds.ebrains.eu/sands/CommonCoordinateSpaceVersion"
+      ]
+    }   
   }
 }

--- a/schemas/products/softwareVersion.schema.tpl.json
+++ b/schemas/products/softwareVersion.schema.tpl.json
@@ -64,7 +64,10 @@
       "uniqueItems": true,
       "_instruction": "Add all software versions that supplement this software version.",
       "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/SoftwareVersion"
+        "https://openminds.ebrains.eu/core/ModelVersion",
+        "https://openminds.ebrains.eu/core/SoftwareVersion",
+        "https://openminds.ebrains.eu/sands/BrainAtlasVersion",
+        "https://openminds.ebrains.eu/sands/CommonCoordinateSpaceVersion"
       ]
     },
     "inputFormat": {
@@ -144,17 +147,6 @@
       "items": {
         "type": "string"
       }
-    },
-    "supportedConstruct":{
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add all constructs (e.g., brain atlas version or model version) that are supported by this software version.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/ModelVersion",
-        "https://openminds.ebrains.eu/sands/BrainAtlasVersion",
-        "https://openminds.ebrains.eu/sands/CommonCoordinateSpaceVersion"
-      ]
-    }   
+    }
   }
 }


### PR DESCRIPTION
this change is overdue and the result of an old discussion. Idea: some software versions specifically support certain constructs (e.g. siibra only supports a certain set of common coordinate spaces which varies across versions of the software.)

note: I'm not fixed on the property name or definition. If you have a better idea please make a suggestion.