### PR TITLE
Create ilastik and webilastik specific content types

### DIFF
--- a/instances/data/contentTypes/application_vnd.ilastik.object-features+csv.jsonld
+++ b/instances/data/contentTypes/application_vnd.ilastik.object-features+csv.jsonld
@@ -10,7 +10,7 @@
     ".csv"
   ],
   "name": "application/vnd.ilastik.object-features+csv",
-  "relatedMediaType": "text/csv",
+  "relatedMediaType": "https://www.iana.org/assignments/media-types/text/csv",
   "synonym": [
     "ilastik object features CSV"
   ]

--- a/instances/data/contentTypes/application_vnd.ilastik.object-features+csv.jsonld
+++ b/instances/data/contentTypes/application_vnd.ilastik.object-features+csv.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.ilastik.object-features+csv",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "description": "The ilastik object-features CSV file is a table with a line for every detected object and a column for every feature (e.g.: size, position) measured on that object.",
+  "displayLabel": "ilastik object features CSV",
+  "fileExtension": [
+    ".csv"
+  ],
+  "name": "application/vnd.ilastik.object-features+csv",
+  "relatedMediaType": "text/csv",
+  "synonym": [
+    "ilastik object features CSV"
+  ]
+}

--- a/instances/data/contentTypes/application_vnd.ilastik.object-features+hdf5.jsonld
+++ b/instances/data/contentTypes/application_vnd.ilastik.object-features+hdf5.jsonld
@@ -1,4 +1,3 @@
-
 {
   "@context": {
     "@vocab": "https://openminds.ebrains.eu/vocab/"

--- a/instances/data/contentTypes/application_vnd.ilastik.object-features+hdf5.jsonld
+++ b/instances/data/contentTypes/application_vnd.ilastik.object-features+hdf5.jsonld
@@ -1,0 +1,18 @@
+
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.ilastik.object-features+hdf5",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "description": null,
+  "displayLabel": "ilastik object features HDF5",
+  "fileExtension": [
+    ".hdf5"
+  ],
+  "name": "application/vnd.ilastik.object-features+hdf5",
+  "relatedMediaType": "application/x-hdf",
+  "synonym": [
+    "ilastik object features HDF5"
+  ]
+}

--- a/instances/data/contentTypes/application_vnd.ilastik.object-features+hdf5.jsonld
+++ b/instances/data/contentTypes/application_vnd.ilastik.object-features+hdf5.jsonld
@@ -10,7 +10,7 @@
     ".hdf5"
   ],
   "name": "application/vnd.ilastik.object-features+hdf5",
-  "relatedMediaType": "application/x-hdf",
+  "relatedMediaType": null,
   "synonym": [
     "ilastik object features HDF5"
   ]

--- a/instances/data/contentTypes/application_vnd.ilastik.object-features+hdf5.jsonld
+++ b/instances/data/contentTypes/application_vnd.ilastik.object-features+hdf5.jsonld
@@ -7,7 +7,8 @@
   "description": null,
   "displayLabel": "ilastik object features HDF5",
   "fileExtension": [
-    ".hdf5"
+    ".hdf5",
+    ".h5"
   ],
   "name": "application/vnd.ilastik.object-features+hdf5",
   "relatedMediaType": null,

--- a/instances/data/contentTypes/application_vnd.ilastik.object-features+hdf5.jsonld
+++ b/instances/data/contentTypes/application_vnd.ilastik.object-features+hdf5.jsonld
@@ -4,7 +4,7 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.ilastik.object-features+hdf5",
   "@type": "https://openminds.ebrains.eu/core/ContentType",
-  "description": null,
+  "description": "The ilastik object features HDF5 file has two data entries: table and images. The images entry contains one image cutout for each object and one mask for each object, marking the pixels occupied by that object. The table entry is saved as a numpy structured array and holds the selected feature values for each object.",
   "displayLabel": "ilastik object features HDF5",
   "fileExtension": [
     ".hdf5",

--- a/instances/data/contentTypes/application_vnd.ilastik.project+hdf5.jsonld
+++ b/instances/data/contentTypes/application_vnd.ilastik.project+hdf5.jsonld
@@ -10,7 +10,7 @@
     ".ilp"
   ],
   "name": "application/vnd.ilastik.project+hdf5",
-  "relatedMediaType": "application/x-hdf",
+  "relatedMediaType": null,
   "synonym": [
     "ilastik project",
     "ilastik project file",

--- a/instances/data/contentTypes/application_vnd.ilastik.project+hdf5.jsonld
+++ b/instances/data/contentTypes/application_vnd.ilastik.project+hdf5.jsonld
@@ -5,7 +5,7 @@
   "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.ilastik.project+hdf5",
   "@type": "https://openminds.ebrains.eu/core/ContentType",
   "description": "The ilastik project file is an hdf5 file with an .ilp extension. It holds the current state of the ilastik application such as what workflow is being used, which images are open and what features to compute on those images.",
-  "displayLabel": "ilastik project file"
+  "displayLabel": "ilastik project file",
   "fileExtension": [
     ".ilp"
   ],

--- a/instances/data/contentTypes/application_vnd.ilastik.project+hdf5.jsonld
+++ b/instances/data/contentTypes/application_vnd.ilastik.project+hdf5.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.ilastik.project+hdf5",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "fileExtension": [
+    ".ilp"
+  ],
+  "name": "application/vnd.ilastik.project+hdf5",
+  "relatedMediaType": null,
+  "synonym": null
+}

--- a/instances/data/contentTypes/application_vnd.ilastik.project+hdf5.jsonld
+++ b/instances/data/contentTypes/application_vnd.ilastik.project+hdf5.jsonld
@@ -4,10 +4,16 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.ilastik.project+hdf5",
   "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "description": "The ilastik project file is an hdf5 file with an .ilp extension. It holds the current state of the ilastik application such as what workflow is being used, which images are open and what features to compute on those images.",
+  "displayLabel": "ilastik project file"
   "fileExtension": [
     ".ilp"
   ],
   "name": "application/vnd.ilastik.project+hdf5",
-  "relatedMediaType": null,
-  "synonym": null
+  "relatedMediaType": "application/x-hdf",
+  "synonym": [
+    "ilastik project",
+    "ilastik project file",
+    "ILP"
+  ]
 }

--- a/instances/data/contentTypes/image_vnd.ilastik+hdf5.jsonld
+++ b/instances/data/contentTypes/image_vnd.ilastik+hdf5.jsonld
@@ -6,7 +6,10 @@
   "@type": "https://openminds.ebrains.eu/core/ContentType",
   "description": null,
   "displayLabel": "ilastik HDF5 image",
-  "fileExtension": null,
+  "fileExtension": [
+    ".hdf5",
+    ".h5"
+  ],
   "name": "image/vnd.ilastik+hdf5",
   "relatedMediaType": null,
   "synonym": [

--- a/instances/data/contentTypes/image_vnd.ilastik+hdf5.jsonld
+++ b/instances/data/contentTypes/image_vnd.ilastik+hdf5.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/image_vnd.ilastik+hdf5",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "description": null,
+  "displayLabel": "ilastik HDF5 image",
+  "fileExtension": null,
+  "name": "image/vnd.ilastik+hdf5",
+  "relatedMediaType": null,
+  "synonym": [
+    "ilastik HDF5 image"
+  ]
+}

--- a/instances/data/contentTypes/image_vnd.ilastik.pixelclassification+hdf5.jsonld
+++ b/instances/data/contentTypes/image_vnd.ilastik.pixelclassification+hdf5.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/image_vnd.ilastik.pixelclassification+hdf5",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "description": null,
+  "displayLabel": "ilastik pixel classification image (HDF5)",
+  "fileExtension": [
+    ".hdf5",
+    ".h5"
+  ],
+  "name": "image/vnd.ilastik.pixelclassification+hdf5",
+  "relatedMediaType": null,
+  "synonym": [
+    "ilastik pixel classification image (HDF5)"
+  ]
+}

--- a/instances/data/contentTypes/image_vnd.ilastik.pixelclassification+hdf5.jsonld
+++ b/instances/data/contentTypes/image_vnd.ilastik.pixelclassification+hdf5.jsonld
@@ -4,7 +4,7 @@
   },
   "@id": "https://openminds.ebrains.eu/instances/contentTypes/image_vnd.ilastik.pixelclassification+hdf5",
   "@type": "https://openminds.ebrains.eu/core/ContentType",
-  "description": null,
+  "description": "The ilastik pixel classification HDF5 file is a multi-channel, f32 image where each channel's value is between 0.0 and 1.0 and represents the likelihood of a pixel belonging to a particular class.",
   "displayLabel": "ilastik pixel classification image (HDF5)",
   "fileExtension": [
     ".hdf5",

--- a/instances/data/contentTypes/image_vnd.ilastik.pixelclassification+n5.jsonld
+++ b/instances/data/contentTypes/image_vnd.ilastik.pixelclassification+n5.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/image_vnd.ilastik.pixelclassification+n5",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "description": "The ilastik pixel classification N5 file is a multi-channel, f32 image where each channel's value is between 0.0 and 1.0 and represents the likelihood of a pixel belonging to a particular class.",
+  "displayLabel": "ilastik pixel classification image (N5)",
+  "fileExtension": [
+    ".n5"
+  ],
+  "name": "image/vnd.ilastik.pixelclassification+n5",
+  "relatedMediaType": null,
+  "synonym": [
+    "ilastik pixel classification image (N5)"
+  ]
+}

--- a/instances/data/contentTypes/image_vnd.ilastik.pixelclassification+neuroglancer.precomputed.jsonld
+++ b/instances/data/contentTypes/image_vnd.ilastik.pixelclassification+neuroglancer.precomputed.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/image_vnd.ilastik.pixelclassification+neuroglancer.precomputed",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "description": "The ilastik pixel classification neuroglancer precomputed file is a multi-channel, f32 image where each channel's value is between 0.0 and 1.0 and represents the likelihood of a pixel belonging to a particular class.",
+  "displayLabel": "ilastik pixel classification image (neuroglancer precomputed)",
+  "fileExtension": null,
+  "name": "image/vnd.ilastik.pixelclassification+neuroglancer.precomputed",
+  "relatedMediaType": null,
+  "synonym": [
+    "ilastik pixel classification image (neuroglancer precomputed)"
+  ]
+}

--- a/instances/data/contentTypes/image_vnd.ilastik.segmentation+dzi.jsonld
+++ b/instances/data/contentTypes/image_vnd.ilastik.segmentation+dzi.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/image_vnd.ilastik.segmentation+dzi",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "description": "The ilastik segmentation DZI file is a uint8 RGB image where each pixel is either red (255,0,0) if that pixel belongs to an object, or black (0,0,0) if that pixel does not belong to an object.",
+  "displayLabel": "ilastik segmentation image (DZI)",
+  "fileExtension": [
+    ".dzi",
+    ".xml"
+  ],
+  "name": "image/vnd.ilastik.segmentation+dzi",
+  "relatedMediaType": null,
+  "synonym": [
+    "ilastik segmentation image (DZI)"
+  ]
+}

--- a/instances/data/contentTypes/image_vnd.ilastik.segmentation+dzip.jsonld
+++ b/instances/data/contentTypes/image_vnd.ilastik.segmentation+dzip.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/image_vnd.ilastik.segmentation+dzip",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "description": "The ilastik segmentation DZIP file is a uint8 RGB image where each pixel is either red (255,0,0) if that pixel belongs to an object, or black (0,0,0) if that pixel does not belong to an object.",
+  "displayLabel": "ilastik segmentation image (DZIP)",
+  "fileExtension": [
+    ".dzip"
+  ],
+  "name": "image/vnd.ilastik.segmentation+dzip",
+  "relatedMediaType": null,
+  "synonym": [
+    "ilastik segmentation image (DZIP)"
+  ]
+}

--- a/instances/data/contentTypes/image_vnd.ilastik.segmentation+n5.jsonld
+++ b/instances/data/contentTypes/image_vnd.ilastik.segmentation+n5.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/image_vnd.ilastik.segmentation+n5",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "description": "The ilastik segmentation N5 file is a uint8 RGB image where each pixel is either red (255,0,0) if that pixel belongs to an object, or black (0,0,0) if that pixel does not belong to an object.",
+  "displayLabel": "ilastik segmentation image (N5)",
+  "fileExtension": [
+    ".n5"
+  ],
+  "name": "image/vnd.ilastik.segmentation+n5",
+  "relatedMediaType": null,
+  "synonym": [
+    "ilastik segmentation image (N5)"
+  ]
+}

--- a/instances/data/contentTypes/image_vnd.ilastik.segmentation+neuroglancer.precomputed
+++ b/instances/data/contentTypes/image_vnd.ilastik.segmentation+neuroglancer.precomputed
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://openminds.ebrains.eu/vocab/"
+  },
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/image_vnd.ilastik.segmentation+neuroglancer.precomputed",
+  "@type": "https://openminds.ebrains.eu/core/ContentType",
+  "description": "The ilastik segmentation neuroglancer computed file is a uint8 RGB image where each pixel is either red (255,0,0) if that pixel belongs to an object, or black (0,0,0) if that pixel does not belong to an object.",
+  "displayLabel": "ilastik segmentation image (neuroglancer precomputed)",
+  "fileExtension": null,
+  "name": "image/vnd.ilastik.segmentation+neuroglancer.precomputed",
+  "relatedMediaType": null,
+  "synonym": [
+    "ilastik segmentation image (neuroglancer precomputed)"
+  ]
+}

--- a/instances/data/contentTypes/image_x-hdf.jsonld
+++ b/instances/data/contentTypes/image_x-hdf.jsonld
@@ -2,17 +2,17 @@
   "@context": {
     "@vocab": "https://openminds.ebrains.eu/vocab/"
   },
-  "@id": "https://openminds.ebrains.eu/instances/contentTypes/image_vnd.ilastik+hdf5",
+  "@id": "https://openminds.ebrains.eu/instances/contentTypes/image_x-hdf",
   "@type": "https://openminds.ebrains.eu/core/ContentType",
   "description": null,
-  "displayLabel": "ilastik HDF5 image",
+  "displayLabel": "HDF5 image",
   "fileExtension": [
     ".hdf5",
     ".h5"
   ],
-  "name": "image/vnd.ilastik+hdf5",
+  "name": "image/x-hdf",
   "relatedMediaType": null,
   "synonym": [
-    "ilastik HDF5 image"
+    "HDF5 image"
   ]
 }


### PR DESCRIPTION
cf. last comments in openMetadataInitiative/openMINDS_instances#10 

- [x] application/vnd.ilastik.project+hdf5
- [x] application/vnd.ilastik.object-features+hdf5
- [x] application/vnd.ilastik.object-features+csv
- [x] image/x-hdf (content type suggestion for generic HDF5 image)
- [x] image/vnd.ilastik.pixelclassification+hdf5
- [x] image/vnd.ilastik.pixelclassification+n5
- [x] image/vnd.ilastik.pixelclassification+neuroglancer.precomputed
- [x] image/vnd.ilastik.segmentation+dzi
- [x] image/vnd.ilastik.segmentation+dzip
- [x] image/vnd.ilastik.segmentation+n5
- [x] image/vnd.ilastik.segmentation+neuroglancer.precomputed