### PR TITLE
Allow ISBN under fullDocumentation (RPV)

### DIFF
--- a/schemas/products/researchProductVersion.schema.tpl.json
+++ b/schemas/products/researchProductVersion.schema.tpl.json
@@ -41,6 +41,7 @@
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/DOI",
         "https://openminds.ebrains.eu/core/File",
+        "https://openminds.ebrains.eu/core/ISBN",
         "https://openminds.ebrains.eu/core/WebResource"
       ]
     },


### PR DESCRIPTION
This is needed for the atlas that I am registering at the moment. All information about the atlas is part of the book. So, the only ID that can be used in this case is the ISBN of the book.