### PR TITLE
Add an "entryPoint" property to ModelVersion as a way to improve specification of how to run simulations with a model

### DIFF
--- a/schemas/products/modelVersion.schema.tpl.json
+++ b/schemas/products/modelVersion.schema.tpl.json
@@ -22,6 +22,10 @@
         "core:SWHID"
       ]
     },
+    "entryPoint": {
+      "type": "string",
+      "_instruction": "Add the entry point for this model version (for example, the path of the main script file within the repository)."
+    },
     "format": {
       "type": "array",
       "minItems": 1,


### PR DESCRIPTION
(cf the same property in openMINDS_computation/validationTestVersion)
