### PR TITLE
Category update originating from SANDS update

### DIFF
--- a/schemas/data/fileBundle.schema.tpl.json
+++ b/schemas/data/fileBundle.schema.tpl.json
@@ -24,7 +24,7 @@
       "uniqueItems": true,
       "_instruction": "Add all entities that defined which files were grouped into this file bundle. Note that the schema types of the instances stated here, need to match the ones stated under 'groupingType'.",
       "_linkedCategories": [
-        "coordinateSpace",
+        "coordinateFramework",
         "fileOrigin",
         "studyTarget"
       ]


### PR DESCRIPTION
see https://github.com/openMetadataInitiative/openMINDS_SANDS/pull/304 

category "coordinateSpace" changed to "coordinateFramework" due to name change of schemas belonging to the category 