### PR TITLE
Add externalDefinitionOfName to numerical/stringProperty schemas

### DIFF
--- a/schemas/research/numericalProperty.schema.tpl.json
+++ b/schemas/research/numericalProperty.schema.tpl.json
@@ -5,6 +5,13 @@
     "value"
   ],
   "properties": {
+    "externalDefinitionOfName": {
+      "type": "string",
+      "_formats": [
+        "iri"
+      ],
+      "_instruction": "Enter the internationalized resource identifier (IRI) to an external definition of the property name."
+    },
     "name": {
       "type": "string",
       "_instruction": "Enter a descriptive name for this numerical property."

--- a/schemas/research/stringProperty.schema.tpl.json
+++ b/schemas/research/stringProperty.schema.tpl.json
@@ -5,6 +5,13 @@
     "value"
   ],
   "properties": {
+    "externalDefinitionOfName": {
+      "type": "string",
+      "_formats": [
+        "iri"
+      ],
+      "_instruction": "Enter the internationalized resource identifier (IRI) to an external definition of the property name."
+    },
     "name": {
       "type": "string",
       "_instruction": "Enter a descriptive name for this property."


### PR DESCRIPTION
Added externalDefinitionOfName property with type and instruction.

Minimal update to solve https://github.com/openMetadataInitiative/openMINDS_core/issues/514